### PR TITLE
Use Relative Path for IDE

### DIFF
--- a/Sources/Pioneer/Http/Pioneer+IDE.swift
+++ b/Sources/Pioneer/Http/Pioneer+IDE.swift
@@ -82,8 +82,8 @@ extension Pioneer {
         </div>
         <script>window.addEventListener('load', function (event) {
             GraphQLPlayground.init(document.getElementById('root'), {
-                endpoint: "/\(path)",
-                subscriptionEndpoint: "/\(path)/websocket"
+                endpoint: "./\(path)",
+                subscriptionEndpoint: "./\(path)/websocket"
             })
         })</script>
         </body>
@@ -110,7 +110,7 @@ extension Pioneer {
                 return """
                 <script src="https://unpkg.com/subscriptions-transport-ws/browser/client.js" type="application/javascript"></script>
                 <script>
-                    const url = '/\(path)';
+                    const url = './\(path)';
                     const subscriptionUrl = 'ws://' + window.location.host + '/\(path)/websocket';
                 
                     const legacyClient = new window.SubscriptionsTransportWs.SubscriptionClient(subscriptionUrl, { reconnect: true });
@@ -130,7 +130,7 @@ extension Pioneer {
             case .graphqlWs:
                 return """
                 <script>
-                    const url = '/\(path)';
+                    const url = './\(path)';
                     const subscriptionUrl = 'ws://' + window.location.host + '/\(path)/websocket';
 
                     const fetcher = GraphiQL.createFetcher({
@@ -148,7 +148,7 @@ extension Pioneer {
             case .disable:
                 return """
                 <script>
-                    const url = '/\(path)';
+                    const url = './\(path)';
 
                     const fetcher = GraphiQL.createFetcher({
                         url


### PR DESCRIPTION
This resolves an issue where the user may choose to provide a non-root route builder to Pioneer.

For example, a user may pass a RouteBuilder through which has a relative path of `/api` which (when the API path of "graphql" is added) would place the resolver at /api/graphql.

Currently, we would still be looking at /graphql which would fail. This patch means it will now look relative to the playground endpoint and correctly maps to /api/graphql in my testing.

--

In order to wrap Pioneer in my own domain/route structure, I've had to pass a custom Vapor route group to the middleware function. This looks a little like this:

```swift
routes.group("gql") { builder in
    server.applyMiddleware(on: builder, at: "")
}
```

The expectation is to have the following routes:

```
api.basedomain.com/gql [QUERY]
api.basedomain.com/gql/playground
api.basedomain.com/gql/websocket
```

With the current URL restriction in place, this does not work for the playground and throws 404 errors as it cannot find the route it needs. By using a relative path, in my use case, it is now working.