### PR TITLE
Update Schema Documentation for Array Relationship

### DIFF
--- a/Documentation/guides/getting-started/schema.md
+++ b/Documentation/guides/getting-started/schema.md
@@ -28,7 +28,7 @@ let schema = try? Schema<Resolver, Context> {
         Field("displayName", at: \.displayName)
 
         // Computed properties with custom resolver (for relationship)
-        Field("friends", at: \.friends)
+        Field("friends", at: User.friends, as: [TypeReference<User>].self)
     }
 
     Input(UserInput.self) {


### PR DESCRIPTION
Lost a little bit of time today trying to understand the compiler and runtime errors thrown when using an array return type from a function.

In the example, `friends` is a function which resolves an array of users.

With the current documentation, this will throw a compiler error complaining about the instance keypath being provided.

When replaced with `User.friends`, it compiles but at runtime you get a crash due to the unsupported array type. By boxing the type using the underlying TypeReference generic, this runtime error goes and it works as expected.

This syntax is demonstrated in the [upstream Star Wars example](https://github.com/GraphQLSwift/Graphiti/blob/9e504c9b41f0a880c80e53148b151b92795af8b6/Tests/GraphitiTests/StarWarsAPI/StarWarsAPI.swift#L43) but the Pioneer documentation did not include this which may cause confusion to new users.