### PR TITLE
Added more information for tackling common problems

### DIFF
--- a/Documentation/guides/features/fluent.md
+++ b/Documentation/guides/features/fluent.md
@@ -3,13 +3,13 @@ icon: database
 order: 60
 ---
 
-# Fluent Integration
+# Fluent
 
-Fluent is the most common choice of connecting to a database from a Vapor application. There can be some confusion on how to connect Fluent entities into a GraphQL Schema.
+Fluent is the most common choice of connecting to a database from a Vapor application. There can be some confusion on how to connect Fluent entities into a GraphQL Schema, so here are some information to help tackle any of those issue.
 
 ## GraphQL ID
 
-As an example, let's use Graphiti as the GraphQL schema library and we have a `User` fluent entity as described below.
+Let's use Graphiti as the GraphQL schema library and we have a `User` fluent entity as described below.
 
 ```swift User.swift
 import Foundation

--- a/Documentation/guides/features/fluent.md
+++ b/Documentation/guides/features/fluent.md
@@ -1,0 +1,150 @@
+---
+icon: database
+order: 60
+---
+
+# Fluent
+
+Fluent is the most common choice of connecting to a database from a Vapor application. There can be some confusion on how to connect Fluent entities into a GraphQL Schema.
+
+## GraphQL ID
+
+As an example, let's use Graphiti as the GraphQL schema library and we have a `User` fluent entity as described below.
+
+```swift User.swift
+import Foundation
+import Vapor
+import Fluent
+
+final class User: Model, Content {
+    static var schema: String = "users"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "name")
+    var name: String
+
+    init() { }
+
+    init(id: UUID? = nil, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+```
+
+Describing this class and most of its properties in Graphiti should be simple enough. However as you can see here, UUID is its struct and not a primitive in the GraphQL spec.
+
+On the other hand, Pioneer already have provided a struct for the GraphQL `ID` primitive. We can take advantage of Swift extensions and computed properties to describe the entity's `UUID` into Pioneer's `ID`.
+
+```swift User+Graphiti.swift
+import Foundation
+import Pioneer
+
+extension User {
+    var gid: ID {
+        if let uuid = id?.uuidString {
+            return .init(uuid)
+        }
+        return .uuid()
+    }
+}
+```
+
+From that, we can use the new computed properties in the schema instead of using the `id` property.
+
+```swift Schema.swift
+import Foundation
+import Graphiti
+import Pioneer
+
+func schema() throws -> Schema<Resolver, Context> {
+    try .init {
+        ID.asScalar()
+
+        Type(User.self) {
+            Field("id", at: \.gid)
+            Field("name", at: \.name)
+        }
+
+        ...
+    }
+}
+```
+
+## Fluent Relationship
+
+Say we have a new struct `Item` that have a many to one relationship to `User`. You can easily describe this into the GraphQL schema with using Swift's extension.
+
+```swift Item.swift
+import Foundation
+import Vapor
+import Fluent
+
+final class Item: Model, Content {
+    static let schema = "items"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "name")
+    var name: String
+
+    @Parent(key: "user_id")
+    var user: User
+
+    init() { }
+
+    init(name: String, userID: User.IDValue) {
+        self.name = name
+        self.$user.id = userID
+    }
+}
+```
+
+Using extensions, we can describe a custom resolver function to fetch the `User` for the `Item`.
+
+```swift Item+Graphiti.swift
+import Foundation
+import Fluent
+import Vapor
+import Pioneer
+import Graphiti
+
+extension Item {
+    func owner(ctx: Context, _: NoArguments) async throws -> User? {
+        return try await User.query(on: ctx.req.db).filter(\.$id == $user.id).first()
+    }
+}
+```
+
+_This example is very simple. However in a real application, you might want to use [`DataLoader`](https://github.com/GraphQLSwift/DataLoader)_
+
+[!ref More on Relationship](/guides/getting-started/resolver.md/#relationship)
+
+And update the schema accordingly.
+
+```swift Schema.swift
+import Foundation
+import Graphiti
+import Pioneer
+
+func schema() throws -> Schema<Resolver, Context> {
+    try .init {
+        ID.asScalar()
+
+        Type(User.self) {
+            Field("id", at: \.gid)
+            Field("name", at: \.name)
+        }
+
+        Type(Item.self) {
+            Field("name", at: \.name)
+            Field("owner", at: Item.owner, as: TypeReference<User>.self)
+        }
+
+        ...
+    }
+}
+```

--- a/Documentation/guides/features/fluent.md
+++ b/Documentation/guides/features/fluent.md
@@ -3,7 +3,7 @@ icon: database
 order: 60
 ---
 
-# Fluent
+# Fluent Integration
 
 Fluent is the most common choice of connecting to a database from a Vapor application. There can be some confusion on how to connect Fluent entities into a GraphQL Schema.
 
@@ -148,3 +148,5 @@ func schema() throws -> Schema<Resolver, Context> {
     }
 }
 ```
+
+This approach is actually not a specific to Pioneer. You can use the same or similar solutions if you are using Vapor, Fluent, and Graphiti, albeit without some features provided by Pioneer (i.e. async await resolver, and custom ID struct).

--- a/Documentation/guides/features/graphql-ide.md
+++ b/Documentation/guides/features/graphql-ide.md
@@ -1,6 +1,6 @@
 ---
 icon: squirrel
-order: 60
+order: 50
 ---
 
 # GraphQL IDE

--- a/Documentation/guides/features/graphql-over-http.md
+++ b/Documentation/guides/features/graphql-over-http.md
@@ -30,3 +30,56 @@ Here are the available strategies:
 | `mutationOnlyPost`       | [!badge variant="success" text="Query"] [!badge variant="warning" text="Mutation"] | [!badge variant="warning" text="Mutation"]                                         |
 | `splitQueryAndMutation`  | [!badge variant="success" text="Query"]                                            | [!badge variant="warning" text="Mutation"]                                         |
 | `both`                   | [!badge variant="success" text="Query"] [!badge variant="warning" text="Mutation"] | [!badge variant="success" text="Query"] [!badge variant="warning" text="Mutation"] |
+
+## Request and Response
+
+Pioneer provide a similar solution to `apollo-server-express` in handling fetching the raw http requests and sending back custom responses. It provide both in the context builder that needed to be provided when constructing Pioneer.
+
+```swift main.swift
+import Pioneer
+import Vapor
+
+let app = try Application(.detect())
+
+func getContext(req: Request, res: Response) -> Context {
+    // Do something extra if needed
+    Context(req: req, res: req)
+}
+
+let server = Pioneer(
+    schema: schema,
+    resolver: Resolver(),
+    contextBuilder: getContext,
+    websocketProtocol: .graphqlWs,
+    introspection: true,
+    playground: .graphiql
+)
+```
+
+### Request
+
+The request given is directly from Vapor, so you can use any method you would use in a regular Vapor application to get any values from it.
+
+```swift Getting a cookie example
+struct Resolver {
+    func someCookie(ctx: Context, _: NoArguments) async -> String {
+        return ctx.req.cookies["some-key"]
+    }
+}
+```
+
+### Response
+
+Pioneer already provided the response object in the context builder that is going to be the one used to respond to the request. You don't need return one, and instead just mutate its properties.
+
+!!!warning Returning custom response
+There is currently no way for a resolver function to return a custom response. Graphiti only take functions that return the type describe in the schema, and Pioneer also have to handle encoding the returned value into a response that follow the proper GraphQL format.
+!!!
+
+```swift Setting a cookie example
+func users(ctx: Context, _: NoArguments) async -> [User] {
+    ctx.response.cookies["refresh-token"] = /* refresh token */
+    ctx.response.cookies["access-token"] = /* access token */
+    return await getUsers()
+}
+```

--- a/Documentation/guides/features/graphql-over-http.md
+++ b/Documentation/guides/features/graphql-over-http.md
@@ -33,7 +33,7 @@ Here are the available strategies:
 
 ## Request and Response
 
-Pioneer provide a similar solution to `apollo-server-express` in handling fetching the raw http requests and sending back custom responses. It provide both in the context builder that needed to be provided when constructing Pioneer.
+Pioneer provide a similar solution to `apollo-server-express` in handling fetching the raw http requests and sending back custom responses. It provide both in the context builder that needed to be provided when constructing Pioneer. This request and response will be request-specific / different for each GraphQL HTTP request.
 
 ```swift main.swift
 import Pioneer
@@ -55,6 +55,12 @@ let server = Pioneer(
     playground: .graphiql
 )
 ```
+
+!!!warning Websocket
+While all subscription resolver can also access the context object, given that subscription is handled via a single websocket connection, the request object is taken from the HTTP request to make the switch in protocol and will not change unless the new connection is made.
+
+On the other hand, the response object serves no function in any subscription resolver. It is also advisable to avoid performing authentication through websocket even though this library can perform GraphQL query and mutation through websocket.
+!!!
 
 ### Request
 

--- a/Documentation/guides/features/graphql-over-websockets.md
+++ b/Documentation/guides/features/graphql-over-websockets.md
@@ -59,15 +59,7 @@ let server = Pioneer(
 
 ### Consideration
 
-Even though the sub-protocol is the recommended option, there are still some consideration to take account of. Adoption for this sub-protocol are somewhat limited outside the Node.js / Javascript ecosystem.
-
-Here are some notable clients and tools that has yet to support [graphql-ws](https://github.com/enisdenjo/graphql-ws) as of 2021:
-
-- [apollo-ios](https://github.com/apollographql/apollo-ios), already an [issue](https://github.com/apollographql/apollo-ios/issues/1622) but not yet resolved.
-- [graphql-kotlin](https://github.com/ExpediaGroup/graphql-kotlin), no issue mentioning the new protocol yet.
-- [graphql-flutter](https://github.com/zino-app/graphql-flutter), already an [issue](https://github.com/zino-app/graphql-flutter/issues/958) but not yet resolved.
-- [gql (python)](https://github.com/graphql-python/gql/), already an [issue](https://github.com/graphql-python/gql/issues/240) but not yet resolved.
-- [Apollo Sandbox](https://www.apollographql.com/docs/studio/explorer/).
+Even though the sub-protocol is the recommended option, there are still some consideration to take account of. Adoption for this sub-protocol are somewhat limited outside the Node.js / Javascript ecosystem or major GraphQL client libraries.
 
 A good amount of other server implementations on many languages have also yet to support this sub-protocol. So, make sure that libraries and frameworks you are using already have support for [graphql-ws](https://github.com/enisdenjo/graphql-ws). If in doubt, it's best to understand how both sub-protocols work and have options to swap between both options.
 


### PR DESCRIPTION
- Added information for some common problems when using this library with Fluent (id and relationship)
- Added explanation on using Response and Request in the context builder
- Updated list of GraphQL Clients which added support for `graphql-ws`

