### PR TITLE
Async-Await DataLoader, Aliases, Playground Fix

### DIFF
--- a/.spy.yml
+++ b/.spy.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+  - platform: macos-spm
+    documentation_targets: [Pioneer]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Get the latest tag for Swift on Linux (non-slim one)
-FROM swift:5.5
+FROM swift:latest
 
 WORKDIR /package
 

--- a/Documentation/guides/features/fluent.md
+++ b/Documentation/guides/features/fluent.md
@@ -44,10 +44,7 @@ import Pioneer
 
 extension User {
     var gid: ID {
-        if let uuid = id?.uuidString {
-            return .init(uuid)
-        }
-        return .uuid()
+        id?.uuidString?.toID() ?? .uuid()
     }
 }
 ```

--- a/Documentation/guides/getting-started/resolver.md
+++ b/Documentation/guides/getting-started/resolver.md
@@ -172,17 +172,13 @@ struct Context {
 
 // Must use the EventLoopPromise API since DataLoader hasn't migrated over to async/await and Pioneer hasn't added extensions
 func makeUserLoader(req: Request) -> DataLoader<ID, User> {
-    return .init() { keys in
-        let promise: EventLoopPromise<User> = req.eventLoop.makePromise(of: User.self)
-
-        promise.completeWithTask {
-            let res = await Datastore.shared.find(with: keys)
-            return keys.compactMap { key in res.first { $0.id == key } }
-        }
-
-        // Map each result to the required enum
-        return promise.futureResult.map { users in
-            users.map { DataLoaderFutureValue.success($0) }
+    return .init(on: req.eventLoop) { keys async in
+        let res = await Datastore.shared.find(with: keys)
+        return keys.map { key in 
+            guard let value = res.first(where: { $0.id == key }) else {
+                return .error(GraphQLError(message: "No item with corresponding key: \(key)"))
+            }
+            return .success(value)
         }
     }
 }

--- a/Documentation/guides/getting-started/resolver.md
+++ b/Documentation/guides/getting-started/resolver.md
@@ -185,8 +185,6 @@ func makeUserLoader(req: Request) -> DataLoader<ID, User> {
 
 ```
 
-DataLoader Async/Await extensions coming soon in later version of Pioneer
-
 +++ Resolver
 
 ```swift

--- a/Documentation/guides/getting-started/setup.md
+++ b/Documentation/guides/getting-started/setup.md
@@ -35,7 +35,7 @@ import PackageDescription
 let package = Package(
     dependencies: [
         .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.61.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.61.1"),
         .package(url: "https://github.com/d-exclaimation/pioneer", from: "0.5.2")
     ],
     targets: [

--- a/Documentation/guides/getting-started/setup.md
+++ b/Documentation/guides/getting-started/setup.md
@@ -35,8 +35,8 @@ import PackageDescription
 let package = Package(
     dependencies: [
         .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.54.0"),
-        .package(url: "https://github.com/d-exclaimation/pioneer", from: "0.5.1")
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.61.0"),
+        .package(url: "https://github.com/d-exclaimation/pioneer", from: "0.5.2")
     ],
     targets: [
         .target(

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "7a4dfe026f6ee0f8ad741b58df74c60af296365d",
-          "version": "1.9.0"
+          "revision": "24425989dadab6d6e4167174791a23d4e2a6d0c3",
+          "version": "1.10.0"
         }
       },
       {
@@ -26,6 +26,15 @@
           "branch": null,
           "revision": "75ea3b627d88221440b878e5dfccc73fd06842ed",
           "version": "4.2.7"
+        }
+      },
+      {
+        "package": "DataLoader",
+        "repositoryURL": "https://github.com/GraphQLSwift/DataLoader.git",
+        "state": {
+          "branch": null,
+          "revision": "bc8ec06d49d8430520ece33351a07da4d8ca2fb4",
+          "version": "2.0.2"
         }
       },
       {
@@ -60,8 +69,17 @@
         "repositoryURL": "https://github.com/vapor/routing-kit.git",
         "state": {
           "branch": null,
-          "revision": "5603b81ceb744b8318feab1e60943704977a866b",
-          "version": "4.3.1"
+          "revision": "9e181d685a3dec1eef1fc6dacf606af364f86d68",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms.git",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
         }
       },
       {
@@ -132,8 +150,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "000ca94f9de92c95b9ac85d44600b7b0fe25a3e5",
-          "version": "1.19.2"
+          "revision": "108ac15087ea9b79abb6f6742699cf31de0e8772",
+          "version": "1.22.0"
         }
       },
       {
@@ -155,12 +173,21 @@
         }
       },
       {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
+        }
+      },
+      {
         "package": "vapor",
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "18e9419cae5049e43ca1e8002ca3cf0449f2c8ed",
-          "version": "4.55.0"
+          "revision": "6c63226a4ab82ce53730eb1afb9ca63866fcf033",
+          "version": "4.61.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,9 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "2.2.0"),
+        .package(url: "https://github.com/GraphQLSwift/DataLoader.git", from: "2.0.0"),
         .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.54.0")
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.61.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -27,7 +28,7 @@ let package = Package(
         .target(
             name: "Pioneer",
             dependencies: [
-                "GraphQL", "Graphiti",
+                "GraphQL", "Graphiti", "DataLoader",
                 .product(name: "Vapor", package: "vapor")
             ]),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "2.2.0"),
         .package(url: "https://github.com/GraphQLSwift/DataLoader.git", from: "2.0.0"),
         .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.61.0")
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.61.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Pioneer/GraphQL/Extensions/DataLoader+AsyncAwait.swift
+++ b/Sources/Pioneer/GraphQL/Extensions/DataLoader+AsyncAwait.swift
@@ -1,0 +1,69 @@
+//  DataLoader+AsyncAwait.swift
+//  
+//
+//  Created by d-exclaimation on 10/06/22.
+//
+
+import Foundation
+import DataLoader
+import Vapor
+
+/// Async-await non-throwing batch loading function
+public typealias AsyncgBatchLoadFunction<Key, Value> = (_ keys: [Key]) async -> [DataLoaderFutureValue<Value>]
+
+/// Async-await throwing batch loading function
+public typealias AsyncThrowingBatchLoadFunction<Key, Value> = (_ keys: [Key]) async throws -> [DataLoaderFutureValue<Value>]
+
+public extension DataLoader {
+    // without throwing
+    
+    convenience init(
+        on req: Request,
+        with options: DataLoaderOptions<Key, Value> = DataLoaderOptions(),
+        load asyncLoadFunction: @escaping AsyncgBatchLoadFunction<Key, Value>
+    ) {
+        self.init(options: options, batchLoadFunction: { keys in
+            req.eventLoop.performWithTask {
+                await asyncLoadFunction(keys)
+            }
+        })
+    }
+    
+    convenience init(
+        on eventLoop: EventLoop,
+        with options: DataLoaderOptions<Key, Value> = DataLoaderOptions(),
+        load asyncLoadFunction: @escaping AsyncgBatchLoadFunction<Key, Value>
+    ) {
+        self.init(options: options, batchLoadFunction: { keys in
+            eventLoop.performWithTask {
+                await asyncLoadFunction(keys)
+            }
+        })
+    }
+    
+    // with throwing
+    
+    convenience init(
+        on req: Request,
+        with options: DataLoaderOptions<Key, Value> = DataLoaderOptions(),
+        throwing asyncThrowingLoadFunction: @escaping AsyncThrowingBatchLoadFunction<Key, Value>
+    ) {
+        self.init(options: options, batchLoadFunction: { keys in
+            req.eventLoop.performWithTask {
+                try await asyncThrowingLoadFunction(keys)
+            }
+        })
+    }
+    
+    convenience init(
+        on eventLoop: EventLoop,
+        with options: DataLoaderOptions<Key, Value> = DataLoaderOptions(),
+        throwing asyncThrowingLoadFunction: @escaping AsyncThrowingBatchLoadFunction<Key, Value>
+    ) {
+        self.init(options: options, batchLoadFunction: { keys in
+            eventLoop.performWithTask {
+                try await asyncThrowingLoadFunction(keys)
+            }
+        })
+    }
+}

--- a/Sources/Pioneer/GraphQL/TypeAliases.swift
+++ b/Sources/Pioneer/GraphQL/TypeAliases.swift
@@ -1,0 +1,32 @@
+//  TypeAliases.swift
+//  
+//
+//  Created by d-exclaimation on 10/06/22.
+//
+
+import Foundation
+
+public typealias _ID = ID
+public typealias _GraphQLRequest = GraphQLRequest
+public typealias _GraphQLMessage = GraphQLMessage
+public typealias _AsyncEventStream = AsyncEventStream
+public typealias _AsyncPubSub = AsyncPubSub
+
+public extension Pioneer {
+    /// An alias for ``Pioneer/ID``
+    typealias ID = _ID
+    
+    /// An alias for ``Pioneer/GraphQLRequest``
+    typealias GraphQLRequest = _GraphQLRequest
+    
+    /// An alias for ``Pioneer/GraphQLMessage``
+    typealias GraphQLMessage = _GraphQLMessage
+    
+    /// An alias for ``Pioneer/AsyncEventStream``
+    typealias AsyncEventStream = _AsyncEventStream
+    
+    /// An alias for ``Pioneer/AsyncPubSub``
+    typealias AsyncPubSub = _AsyncPubSub
+}
+
+

--- a/Sources/Pioneer/Http/Pioneer+IDE.swift
+++ b/Sources/Pioneer/Http/Pioneer+IDE.swift
@@ -80,12 +80,15 @@ extension Pioneer {
                 <span class="title">GraphQL Playground</span>
             </div>
         </div>
-        <script>window.addEventListener('load', function (event) {
-            GraphQLPlayground.init(document.getElementById('root'), {
-                endpoint: "./\(path)",
-                subscriptionEndpoint: "./\(path)/websocket"
+        <script>
+            const subscriptionEndpoint = window.location.href.replace("playground", "\(path)/websocket").replace("http", "ws");
+            window.addEventListener('load', function (event) {
+                GraphQLPlayground.init(document.getElementById('root'), {
+                    endpoint: "./\(path)",
+                    subscriptionEndpoint
+                })
             })
-        })</script>
+        </script>
         </body>
 
         </html>


### PR DESCRIPTION
- Fixed issue with name collision by adding type-aliases under `Pioneer`
- Fixed issue with `.playground` subscription endpoint to use computed relative path instead of `./`
- Added async-await extensions for DataLoader