### PR TITLE
Async-await and/or throwing function for Context builder

### DIFF
--- a/Documentation/guides/getting-started/setup.md
+++ b/Documentation/guides/getting-started/setup.md
@@ -36,7 +36,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.61.1"),
-        .package(url: "https://github.com/d-exclaimation/pioneer", from: "0.5.2")
+        .package(url: "https://github.com/d-exclaimation/pioneer", from: "0.6.0")
     ],
     targets: [
         .target(

--- a/Documentation/references/pioneer.md
+++ b/Documentation/references/pioneer.md
@@ -107,7 +107,7 @@ let server = try Pioneer(
 | ------------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
 | `schema`            | [!badge variant="warning" text="Schema<Resolver, Context>"]  | Graphiti schema used to execute operations                                             |
 | `resolver`          | [!badge variant="success" text="Resolver"]                   | Resolver used by the GraphQL schema                                                    |
-| `contextBuilder`    | [!badge variant="danger" text="(Request, Response) -> Void"] | Context builder from request                                                           |
+| `contextBuilder`    | [!badge variant="danger" text="(Request, Response) async throws -> Void"] | Context builder from request (Can be async and can throw an error)                                                        |
 | `httpStrategy`      | [!badge variant="primary" text="HTTPStrategy"]               | HTTP strategy <br/> **Default**: `.queryOnlyGet`                                       |
 | `websocketProtocol` | [!badge variant="primary" text="WebsocketProtocol"]          | Websocket sub-protocol <br/> **Default**: `.subscriptionsTransportws`                  |
 | `introspection`     | [!badge variant="primary" text="Bool"]                       | Allowing introspection <br/> **Default**: `true`                                       |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pioneer is a open-source Swift GraphQL server, for [Vapor](https://github.com/va
 ## Setup
 
 ```swift
-.package(url: "https://github.com/d-exclaimation/pioneer", from: "0.5.2")
+.package(url: "https://github.com/d-exclaimation/pioneer", from: "0.6.0")
 ```
 
 ## Swift for GraphQL

--- a/Sources/Pioneer/Extensions/Pioneer+Graphiti.swift
+++ b/Sources/Pioneer/Extensions/Pioneer+Graphiti.swift
@@ -21,7 +21,7 @@ public extension Pioneer {
     init(
         schema: Schema<Resolver, Context>,
         resolver: Resolver,
-        contextBuilder: @escaping (Request, Response) -> Context,
+        contextBuilder: @escaping @Sendable (Request, Response) async throws -> Context,
         httpStrategy: HTTPStrategy = .queryOnlyGet,
         websocketProtocol: WebsocketProtocol = .subscriptionsTransportWs,
         introspection: Bool = true,

--- a/Sources/Pioneer/Pioneer.swift
+++ b/Sources/Pioneer/Pioneer.swift
@@ -145,10 +145,12 @@ public struct Pioneer<Resolver, Context> {
                 operationName: gql.operationName
             )
             try res.content.encode(result)
-            return res
         } catch {
-            throw GraphQLError(error)
+            try res.content.encode(GraphQLResult(data: nil, errors: [
+                error as? GraphQLError ?? GraphQLError(error)
+            ]))
         }
+        return res
     }
 
     /// Guard for operation allowed

--- a/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
+++ b/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
@@ -31,28 +31,32 @@ extension Pioneer {
 
             return req.webSocket(shouldUpgrade: shouldUpgrade) { req, ws in
                 Task.init {
-                    let res = Response()
-                    let ctx = try await contextBuilder(req, res)
-                    let process = Process(ws: ws, ctx: ctx, req: req)
-                    
-                    try await ws.sendPing()
-                    
-                    /// Scheduled keep alive message interval
-                    let keepAlive: KeepAlive = setInterval(delay: 12_500_000_000) {
-                        if ws.isClosed {
-                            throw GraphQLError(message: "WebSocket closed before any termination")
+                    do {
+                        let res = Response()
+                        let ctx = try await contextBuilder(req, res)
+                        let process = Process(ws: ws, ctx: ctx, req: req)
+                        
+                        try? await ws.sendPing()
+                        
+                        /// Scheduled keep alive message interval
+                        let keepAlive: KeepAlive = setInterval(delay: 12_500_000_000) {
+                            if ws.isClosed {
+                                throw GraphQLError(message: "WebSocket closed before any termination")
+                            }
+                            process.send(websocketProtocol.keepAliveMessage)
                         }
-                        process.send(websocketProtocol.keepAliveMessage)
-                    }
-                    
-                    ws.onText { _, txt in
-                        Task.init {
-                            await onMessage(process: process, keepAlive: keepAlive, txt: txt)
+                        
+                        ws.onText { _, txt in
+                            Task.init {
+                                await onMessage(process: process, keepAlive: keepAlive, txt: txt)
+                            }
                         }
-                    }
-                    
-                    ws.onClose.whenComplete { _ in
-                        onEnd(pid: process.id, keepAlive: keepAlive)
+                        
+                        ws.onClose.whenComplete { _ in
+                            onEnd(pid: process.id, keepAlive: keepAlive)
+                        }
+                    } catch {
+                        try? await ws.close()
                     }
                 }
             }


### PR DESCRIPTION
- Changed the context builder into an async throwing function
- Updated the use of context builder in HTTP and WebSocket portion of Pioneer
- Added error handling for the `handle` function to format error into `GraphQLError`