### PR TITLE
Embedded Sandbox and Improvement to IDE configuration

### DIFF
--- a/Documentation/guides/features/graphql-ide.md
+++ b/Documentation/guides/features/graphql-ide.md
@@ -13,11 +13,11 @@ Pioneer will disable any GraphQL IDE automatically regardless of the specified p
 
 ## GraphiQL
 
-GraphiQL is the official GraphQL IDE by the GraphQL Foundation. The current GraphiQL version has met feature parody with [GraphQL Playground](#graphql-playground).
+GraphiQL is the official GraphQL IDE by the GraphQL Foundation. The current GraphiQL version has met feature parody with [GraphQL Playground](#graphql-playground) (*mostly).
 
 ![](/static/graphiql.png)
 
-[GraphiQL](#graphiql) is self hosted in-browser version (There is an electron app for it). Pioneer can host (by default) [GraphiQL](#graphiql) at the `/playground` endpoint.
+[GraphiQL](#graphiql) is self hosted in-browser version (There is an electron app for it). Pioneer can host [GraphiQL](#graphiql) at the `/playground` endpoint.
 
 ```swift
 let server = Pioneer(
@@ -37,6 +37,8 @@ WS /graphql/websocket
 
 GET /playground # (For GraphiQL)
 ```
+
+[GraphiQL](#graphiql) is the current default option for IDE as it is the only IDE that can be locally hosted and have the most support for all GraphQL features. Despite that, we still recommend trying out the other options to see which one fits your use case best.
 
 ## GraphQL Playground
 
@@ -71,16 +73,25 @@ GET /playground # (For playground)
 
 ## Apollo Sandbox
 
-Apollo Sandbox is a cloud hosted in browser GraphQL IDE developed by Apollo GraphQL and their choice of replacement for [GraphQL Playground](#graphql-playground). Apollo Sandbox provide all features available in [GraphQL Playground](#graphql-playground) and more. However, this is a cloud based solution that require CORS configuration, cannot be self-hosted, and is not open source.
+Apollo Sandbox is a cloud hosted in browser GraphQL IDE developed by Apollo GraphQL and their choice of replacement for [GraphQL Playground](#graphql-playground). Apollo Sandbox provide all features available in [GraphQL Playground](#graphql-playground) and a lot more. However, this is either:
+
+- A cloud based solution that require CORS configuration and cannot be self-hosted, or
+- A locally embedded solution that limited capabilities compared to the cloud version. 
+
+Both solutions is not open source.
 
 ![](/static/sandbox.jpeg)
 
-Pioneer can provide redirecting route (at [/playground](http://localhost:8080/playground)) to Apollo Sandbox and a `CORSMiddleware.Configuration` for the purpose of allowing Apollo Sandbox through CORS.
+Pioneer can provide 2 option for setting up Apollo Sandbox:
+
++++ Cloud Redirect (Preffered)
+
+Redirecting route (at [/playground](http://localhost:8080/playground)) to Apollo Sandbox and a `CORSMiddleware.Configuration` for the purpose of allowing Apollo Sandbox through CORS.
 
 ```swift
 let server = Pioneer(
     ...,
-    playground: .apolloSandbox
+    playground: .apolloSandboxRedirect // or .apolloSandbox
 )
 let cors = CORSMiddleware(configuration: .graphqlWithApolloSandbox())
 
@@ -91,7 +102,29 @@ server.applyMiddleware(on: app)
 
 <sub>You can also just set this up on your own</sub>
 
-Afterwards, you can go to [http://sandbox.apollo.dev/?endpoint=\<your-endpoint-here\>](http://sandbox.apollo.dev/?endpoint=http://localhost:8080/graphql) to open a instance of Apollo Sandbox set to make request to the specified endpoint.
++++ Embedded Locally 
+
+Embedded version of Apollo Sandbox served similarly to [GraphiQL](#graphiql) without needing to setup CORS.
+
+```swift
+let server = Pioneer(
+    ...,
+    playground: .embeddedSandbox
+)
+
+server.applyMiddleware(on: app)
+```
+
+!!!warning Limited
+The embedded version of [Apollo Sandbox](https://www.apollographql.com/docs/studio/explorer/sandbox/#embedding-sandbox) has some limitation notably the lack of subscription support that is available for the regular [Sandbox](https://studio.apollographql.com/sandbox/explorer).
+
+Given that, the preffered / default option for `apolloSandbox` is the redirect option.
+!!!
+
++++
+
+
+Afterwards, you can go to [./playground](http://localhost:8080/playground) to open a instance of Apollo Sandbox whether it is the cloud or the locally embedded version.
 
 ## Banana Cake Pop
 

--- a/Documentation/guides/features/graphql-ide.md
+++ b/Documentation/guides/features/graphql-ide.md
@@ -91,7 +91,7 @@ Redirecting route (at [/playground](http://localhost:8080/playground)) to Apollo
 ```swift
 let server = Pioneer(
     ...,
-    playground: .apolloSandboxRedirect // or .apolloSandbox
+    playground: .apolloSandbox // or .redirect(to: .apolloSandbox)
 )
 let cors = CORSMiddleware(configuration: .graphqlWithApolloSandbox())
 
@@ -109,7 +109,7 @@ Embedded version of Apollo Sandbox served similarly to [GraphiQL](#graphiql) wit
 ```swift
 let server = Pioneer(
     ...,
-    playground: .embeddedSandbox
+    playground: .sandbox
 )
 
 server.applyMiddleware(on: app)
@@ -137,7 +137,7 @@ Pioneer also can provide redirecting route (at [/playground](http://localhost:80
 ```swift
 let server = Pioneer(
     ...,
-    playground: .bananaCakePop
+    playground: .redirect(to: .bananaCakePop)
 )
 let cors = CORSMiddleware(configuration: .graphqlWithBananaCakePop())
 

--- a/Documentation/guides/features/graphql-over-websockets.md
+++ b/Documentation/guides/features/graphql-over-websockets.md
@@ -13,12 +13,11 @@ To perform GraphQL over WebSocket, there need to be a sub protocol to define ope
 
 The newer sub-protocol is [graphql-ws](https://github.com/enisdenjo/graphql-ws). Aimed mostly on solving most of the problem with the [subscriptions-transport-ws](#subscriptions-transport-ws).
 
-!!!success GraphiQL :heart: graphql-ws
-GraphiQL has full support for `graphql-ws` and Pioneer (since `0.3.0`) can now host GraphiQL with this support (and `subscriptions-transport-ws` support).
+!!!success GraphQL IDEs :heart: graphql-ws
+All major GraphQL IDEs (such as GraphiQL, Apollo Sandbox, BananaCakePop, etc.) has full support for `graphql-ws`. 
 
 !!!warning Incompatibilty
-The retired [graphql-playground](https://github.com/graphql/graphql-playground), cloud based IDE such as [Apollo Sandbox](https://studio.apollographql.com/sandbox), some clients and servers has yet to support this protocol. More explaination [here](#consideration).
-
+The [graphql-playground](https://github.com/graphql/graphql-playground) has been retired and will not support `graphql-ws`. More explaination [here](#https://github.com/graphql/graphql-playground/issues/1143).
 !!!
 
 #### Usage

--- a/Documentation/references/enums.md
+++ b/Documentation/references/enums.md
@@ -42,7 +42,7 @@ GraphiQL Browser IDE
 
 |||
 
-||| `embeddedSandbox`
+||| `sandbox`
 
 Embedded Apollo Sandbox Browser IDE 
 
@@ -54,21 +54,15 @@ Given that, the preffered / default option for `apolloSandbox` is the redirect o
 
 |||
 
-||| `apolloSandboxRedirect`
+||| <code>redirect(to: [Cloud](#idecloud))</code>
 
-Redirect to Apollo Sandbox
+Redirect to a cloud based IDE
 
 |||
 
 ||| `apolloSandbox`
 
-Alias for the preferred Apollo Sandbox option (Currently `.apolloSandboxRedirect`)
-
-|||
-
-||| `bananaCakePop`
-
-Redirect to Banana Cake Pop for the cloud)
+Alias for the preferred Apollo Sandbox option (Currently `.redirect(to: .apolloSandbox)`)
 
 |||
 
@@ -77,6 +71,23 @@ Redirect to Banana Cake Pop for the cloud)
 Disabled any IDEs
 
 |||
+
+### IDE.Cloud
+
+GraphQL cloud based IDE options.
+
+||| `apolloSandbox`
+
+Cloud version of Apollo Sandbox
+
+|||
+
+||| `bananaCakePop`
+
+Cloud version of Banana Cake Pop
+
+|||
+
 
 ## HTTPStrategy
 

--- a/Documentation/references/enums.md
+++ b/Documentation/references/enums.md
@@ -42,9 +42,27 @@ GraphiQL Browser IDE
 
 |||
 
-||| `apolloSandbox`
+||| `embeddedSandbox`
+
+Embedded Apollo Sandbox Browser IDE 
+
+!!!warning Limited
+The embedded version of [Apollo Sandbox](https://www.apollographql.com/docs/studio/explorer/sandbox/#embedding-sandbox) has some limitation notably the lack of subscription support that is available for the regular [Sandbox](https://studio.apollographql.com/sandbox/explorer).
+
+Given that, the preffered / default option for `apolloSandbox` is the redirect option.
+!!!
+
+|||
+
+||| `apolloSandboxRedirect`
 
 Redirect to Apollo Sandbox
+
+|||
+
+||| `apolloSandbox`
+
+Alias for the preferred Apollo Sandbox option (Currently `.apolloSandboxRedirect`)
 
 |||
 

--- a/Sources/Pioneer/Http/Pioneer+IDE.swift
+++ b/Sources/Pioneer/Http/Pioneer+IDE.swift
@@ -17,21 +17,26 @@ extension Pioneer {
         case graphiql
         
         /// Embedded Apollo Sandbox
-        case embeddedSandbox
+        case sandbox
         
-        /// Redirect to Apollo Sandbox
-        case apolloSandboxRedirect
-        
-        /// Redirect to Banana Cake Pop
-        case bananaCakePop
+        /// Redirect to a cloud based IDE
+        case redirect(to cloud: Cloud)
         
         /// Disabled any IDEs
         case disable
         
+        public enum Cloud {
+            /// Cloud version of Apollo Sandbox
+            case apolloSandbox
+            
+            /// Cloud version of Banana Cake Pop
+            case bananaCakePop
+        }
+        
         
         /// Alias for the preferred Apollo Sandbox option (Currently ``Pioneer/Pioneer/IDE/apolloSandboxRedirect``)
         public static var apolloSandbox: IDE {
-            .apolloSandboxRedirect
+            .redirect(cloud: .apolloSandbox)
         }
     }
     

--- a/Sources/Pioneer/Http/Pioneer+IDE.swift
+++ b/Sources/Pioneer/Http/Pioneer+IDE.swift
@@ -29,7 +29,7 @@ extension Pioneer {
         case disable
         
         
-        /// Default IDE approach for Apollo Sandbox (Redirect)
+        /// Alias for the preferred Apollo Sandbox option (Currently ``Pioneer/Pioneer/IDE/apolloSandboxRedirect``)
         public static var apolloSandbox: IDE {
             .apolloSandboxRedirect
         }

--- a/Sources/Pioneer/Http/Pioneer+IDE.swift
+++ b/Sources/Pioneer/Http/Pioneer+IDE.swift
@@ -20,7 +20,7 @@ extension Pioneer {
         case sandbox
         
         /// Redirect to a cloud based IDE
-        case redirect(to cloud: Cloud)
+        case redirect(to: Cloud)
         
         /// Disabled any IDEs
         case disable
@@ -36,7 +36,7 @@ extension Pioneer {
         
         /// Alias for the preferred Apollo Sandbox option (Currently ``Pioneer/Pioneer/IDE/apolloSandboxRedirect``)
         public static var apolloSandbox: IDE {
-            .redirect(cloud: .apolloSandbox)
+            .redirect(to: .apolloSandbox)
         }
     }
     

--- a/Sources/Pioneer/Http/Pioneer+IDE.swift
+++ b/Sources/Pioneer/Http/Pioneer+IDE.swift
@@ -34,7 +34,7 @@ extension Pioneer {
         }
         
         
-        /// Alias for the preferred Apollo Sandbox option (Currently ``Pioneer/Pioneer/IDE/apolloSandboxRedirect``)
+        /// Alias for the preferred Apollo Sandbox option (Currently `.redirect(to: .apolloSandbox)`)
         public static var apolloSandbox: IDE {
             .redirect(to: .apolloSandbox)
         }

--- a/Sources/Pioneer/Pioneer.swift
+++ b/Sources/Pioneer/Pioneer.swift
@@ -114,11 +114,11 @@ public struct Pioneer<Resolver, Context> {
             applyPlayground(on: router, at: path)
         case .graphiql:
             applyGraphiQL(on: router, at: path)
-        case .embeddedSandbox:
+        case .sandbox:
             applyEmbeddedSandbox(on: router, at: path)
-        case .apolloSandboxRedirect:
+        case .redirect(cloud: .apolloSandbox):
             applySandboxRedirect(on: router, with: "https://studio.apollographql.com/sandbox/explorer")
-        case .bananaCakePop:
+        case .redirect(cloud: .bananaCakePop):
             applySandboxRedirect(on: router, with: "https://eat.bananacakepop.com")
         case .disable:
             break

--- a/Sources/Pioneer/Pioneer.swift
+++ b/Sources/Pioneer/Pioneer.swift
@@ -114,7 +114,9 @@ public struct Pioneer<Resolver, Context> {
             applyPlayground(on: router, at: path)
         case .graphiql:
             applyGraphiQL(on: router, at: path)
-        case .apolloSandbox:
+        case .embeddedSandbox:
+            applyEmbeddedSandbox(on: router, at: path)
+        case .apolloSandboxRedirect:
             applySandboxRedirect(on: router, with: "https://studio.apollographql.com/sandbox/explorer")
         case .bananaCakePop:
             applySandboxRedirect(on: router, with: "https://eat.bananacakepop.com")

--- a/Sources/Pioneer/Pioneer.swift
+++ b/Sources/Pioneer/Pioneer.swift
@@ -116,9 +116,9 @@ public struct Pioneer<Resolver, Context> {
             applyGraphiQL(on: router, at: path)
         case .sandbox:
             applyEmbeddedSandbox(on: router, at: path)
-        case .redirect(cloud: .apolloSandbox):
+        case .redirect(to: .apolloSandbox):
             applySandboxRedirect(on: router, with: "https://studio.apollographql.com/sandbox/explorer")
-        case .redirect(cloud: .bananaCakePop):
+        case .redirect(to: .bananaCakePop):
             applySandboxRedirect(on: router, with: "https://eat.bananacakepop.com")
         case .disable:
             break


### PR DESCRIPTION
- Added `.sandbox` option for embedded Apollo Sandbox
- Updated redirect options to use `.redirect(to:)` 
- Added `IDE.Cloud` to seperate the cloud IDEs
- Added `.apolloSandbox` static computed property for compatibility reasons