### PR TITLE
HTTP Encoding and WebSocket Security Improvement

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -26,7 +26,7 @@ You can add Pioneer into any existing Vapor application with any GraphQL schema 
 Add this line to add Pioneer as one of your dependencies.
 
 ```swift
-.package(url: "https://github.com/d-exclaimation/pioneer", from: "0.9.4")
+.package(url: "https://github.com/d-exclaimation/pioneer", from: "0.10.0")
 ```
 
 Go to the `main.swift` or any Swift file where you apply your Vapor routing like your `routes.swift` file.

--- a/Documentation/features/async-await.md
+++ b/Documentation/features/async-await.md
@@ -74,7 +74,7 @@ import NIO
 
 extension EventLoop {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    func makeFutureWithTask<Value>(_ body: @escaping @Sendable () async throws -> Value) -> EventLoopFuture<Value> {
+    func makeFutureWithTask<Value>(_ body: @Sendable @escaping () async throws -> Value) -> EventLoopFuture<Value> {
         let promise = eventLoop.makePromise(of: Value.self)
         promise.completeWithTask(body)
         return promise.futureResult

--- a/Documentation/features/graphql-over-http.md
+++ b/Documentation/features/graphql-over-http.md
@@ -197,6 +197,10 @@ Pioneer also provide handler to manually setting routes for WebSocket
 [!ref Manual WebSocket Routing](/features/graphql-over-websocket/#manual-websocket-routing)
 !!!
 
+!!!success Custom ContentEncoder
+Since `v0.10.0`, There is `.httpHandler(req:using:)` method that can take a custom `ContentEncoder`
+!!!
+
 ```swift
 let app = try Application(.detect())
 let server = try Pioneer(...)

--- a/Documentation/guides/advanced/context.md
+++ b/Documentation/guides/advanced/context.md
@@ -209,3 +209,28 @@ struct Resolver {
 ```
 
 [!ref GraphQLRequest API References](/references/structs/#graphqlrequest)
+
+## WebSocket Initialisation Hook and Authorization
+
+There might be times where you want to authorize any incoming WebSocket connection before any operation done, and thus before the context builder is executed. 
+
+Since `v0.10.0`, Pioneer now provide a way to run custom code during the GraphQL over WebSocket initialisation phase that can deny a WebSocket connection by throwing an error. 
+
+```swift
+let server = Pioneer(
+    schema: schema,
+    resolver: Resolver(),
+    contextBuilder: getContext,
+    websocketContextBuilder: getWebsocketContext,
+    websocketOnInit: { payload in 
+        guard .some(.string(let token)) = payload?["Authorization"] {
+            throw Abort(.unauthorized)
+        }
+
+        // do something with the Authorization token
+    },
+    websocketProtocol: .graphqlWs,
+    introspection: true,
+    playground: .graphiql
+)
+```

--- a/Documentation/guides/getting-started/setup.md
+++ b/Documentation/guides/getting-started/setup.md
@@ -36,7 +36,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.61.1"),
-        .package(url: "https://github.com/d-exclaimation/pioneer", from: "0.9.4")
+        .package(url: "https://github.com/d-exclaimation/pioneer", from: "0.10.0")
     ],
     targets: [
         .target(

--- a/Documentation/references/pioneer.md
+++ b/Documentation/references/pioneer.md
@@ -48,6 +48,7 @@ let server = Pioneer(
 | `playground`              | [!badge variant="primary" text="IDE"]                                                                | Allowing playground <br/> **Default**: `.graphiql`                                     |
 | `validationRules`         | [!badge variant="primary" text="Validations"]                                                        | Validation rules to be applied before operation <br/> **Default**: `.none`             |
 | `keepAlive`               | [!badge variant="warning" text="UInt64?"]                                                            | Keep alive internal in nanosecond, `nil` for disabling <br/> **Default**: 12.5 seconds |
+| `timeout`               | [!badge variant="warning" text="UInt64?"]                                                            | Timeout interval in nanosecond, `nil` for disabling <br/> **Default**: 5 seconds |
 
 ===
 
@@ -88,6 +89,7 @@ let server = Pioneer(
 | `playground`        | [!badge variant="primary" text="IDE"]                                        | Allowing playground <br/> **Default**: `.graphiql`                                     |
 | `validationRules`   | [!badge variant="primary" text="Validations"]                                | Validation rules to be applied before operation <br/> **Default**: `.none`             |
 | `keepAlive`         | [!badge variant="warning" text="UInt64?"]                                    | Keep alive internal in nanosecond, `nil` for disabling <br/> **Default**: 12.5 seconds |
+| `timeout`               | [!badge variant="warning" text="UInt64?"]                                                            | Timeout interval in nanosecond, `nil` for disabling <br/> **Default**: 5 seconds |
 
 ===
 
@@ -124,6 +126,7 @@ let server = Pioneer(
 | `playground`        | [!badge variant="primary" text="IDE"]               | Allowing playground <br/> **Default**: `.graphiql`                                     |
 | `validationRules`   | [!badge variant="primary" text="Validations"]       | Validation rules to be applied before operation <br/> **Default**: `.none`             |
 | `keepAlive`         | [!badge variant="warning" text="UInt64?"]           | Keep alive internal in nanosecond, `nil` for disabling <br/> **Default**: 12.5 seconds |
+| `timeout`               | [!badge variant="warning" text="UInt64?"]                                                            | Timeout interval in nanosecond, `nil` for disabling <br/> **Default**: 5 seconds |
 
 ===
 
@@ -164,6 +167,7 @@ let server = try Pioneer(
 | `playground`        | [!badge variant="primary" text="IDE"]                                     | Allowing playground <br/> **Default**: `.graphiql`                                     |
 | `validationRules`   | [!badge variant="primary" text="Validations"]                             | Validation rules to be applied before operation <br/> **Default**: `.none`             |
 | `keepAlive`         | [!badge variant="warning" text="UInt64?"]                                 | Keep alive internal in nanosecond, `nil` for disabling <br/> **Default**: 12.5 seconds |
+| `timeout`               | [!badge variant="warning" text="UInt64?"]                                                            | Timeout interval in nanosecond, `nil` for disabling <br/> **Default**: 5 seconds |
 
 ===
 
@@ -212,6 +216,7 @@ let server = try Pioneer(
 | `playground`              | [!badge variant="primary" text="IDE"]                                                                | Allowing playground <br/> **Default**: `.graphiql`                                     |
 | `validationRules`         | [!badge variant="primary" text="Validations"]                                                        | Validation rules to be applied before operation <br/> **Default**: `.none`             |
 | `keepAlive`               | [!badge variant="warning" text="UInt64?"]                                                            | Keep alive internal in nanosecond, `nil` for disabling <br/> **Default**: 12.5 seconds |
+| `timeout`               | [!badge variant="warning" text="UInt64?"]                                                            | Timeout interval in nanosecond, `nil` for disabling <br/> **Default**: 5 seconds |
 
 ===
 
@@ -279,6 +284,37 @@ app.post("/manual") { req async throws in
 | Name  | Type                                      | Description                 |
 | ----- | ----------------------------------------- | --------------------------- |
 | `req` | [!badge variant="primary" text="Request"] | The HTTP request being made |
+
+===
+
+---
+
+### `httpHandler`
+
+Common Handler for GraphQL through HTTP using custom `ContentEncoder`
+
+!!!info Manually handling request
+If you use [`applyMiddleware`](#applymiddleware), this function is already in use and does not need to be called.
+
+However, you can opt out of [`applyMiddleware`](#applymiddleware), manually set your HTTP routes, and use this method to handle GraphQL request
+!!!
+
+=== Example
+
+```swift
+app.post("/manual") { req async throws in
+    try await server.httpHandler(req: req, using: JSONEncoder())
+}
+```
+
+===
+
+==- Options
+
+| Name  | Type                                      | Description                 |
+| ----- | ----------------------------------------- | --------------------------- |
+| `req` | [!badge variant="primary" text="Request"] | The HTTP request being made |
+| `encoder` | [!badge variant="warning" text="ContentEncoder"] | The custom content encoder |
 
 ===
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -83,6 +83,15 @@
         }
       },
       {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+          "version": "1.0.2"
+        }
+      },
+      {
         "package": "swift-backtrace",
         "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
         "state": {
@@ -195,8 +204,8 @@
         "repositoryURL": "https://github.com/vapor/websocket-kit.git",
         "state": {
           "branch": null,
-          "revision": "09212f4c2b9ebdef00f04b913b57f5d77bc4ea62",
-          "version": "2.4.1"
+          "revision": "2d9d2188a08eef4a869d368daab21b3c08510991",
+          "version": "2.6.1"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pioneer is an open-source Swift GraphQL server for [Vapor](https://github.com/va
 ## Setup
 
 ```swift
-.package(url: "https://github.com/d-exclaimation/pioneer", from: "0.9.4")
+.package(url: "https://github.com/d-exclaimation/pioneer", from: "0.10.0")
 ```
 
 ## Swift for GraphQL

--- a/Sources/Pioneer/Extensions/Futures/Actor+EventLoopFuture.swift
+++ b/Sources/Pioneer/Extensions/Futures/Actor+EventLoopFuture.swift
@@ -13,7 +13,7 @@ extension Actor {
     /// - Parameters:
     ///   - future: EventLoopFuture value being awaited
     ///   - to: Transforming callback to for the result from the Future.
-    public func pipeToSelf<U>(future: EventLoopFuture<U>, to callback: @escaping @Sendable (Self, Result<U, Error>) async -> Void) {
+    public func pipeToSelf<U>(future: EventLoopFuture<U>, to callback: @Sendable @escaping (Self, Result<U, Error>) async -> Void) {
         Task {
             do {
                 let res = try await future.get()

--- a/Sources/Pioneer/Extensions/Pioneer+Default.swift
+++ b/Sources/Pioneer/Extensions/Pioneer+Default.swift
@@ -19,6 +19,7 @@ public extension Pioneer {
     ///   - playground: Allowing playground
     ///   - validationRules: Validation rules to be applied before operation
     ///   - keepAlive: Keep alive internal in nanosecond, default to 12.5 sec, nil for disable
+    ///   - timeout: Timeout interval in nanosecond, default to 5 sec, nil for disable
     init(
         schema: GraphQLSchema,
         resolver: Resolver,
@@ -28,7 +29,8 @@ public extension Pioneer {
         introspection: Bool = true,
         playground: IDE = .graphiql,
         validationRules: Validations = .none,
-        keepAlive: UInt64? = 12_500_000_000
+        keepAlive: UInt64? = 12_500_000_000,
+        timeout: UInt64? = 5_000_000_000
     ) {
         self.init(
             schema: schema,
@@ -46,7 +48,8 @@ public extension Pioneer {
             introspection: introspection,
             playground: playground,
             validationRules: validationRules,
-            keepAlive: keepAlive
+            keepAlive: keepAlive,
+            timeout: timeout
         )
     }
 }

--- a/Sources/Pioneer/Extensions/Pioneer+Default.swift
+++ b/Sources/Pioneer/Extensions/Pioneer+Default.swift
@@ -22,7 +22,7 @@ public extension Pioneer {
     init(
         schema: GraphQLSchema,
         resolver: Resolver,
-        contextBuilder: @escaping @Sendable (Request, Response) async throws -> Context,
+        contextBuilder: @Sendable @escaping (Request, Response) async throws -> Context,
         httpStrategy: HTTPStrategy = .queryOnlyGet,
         websocketProtocol: WebsocketProtocol = .graphqlWs,
         introspection: Bool = true,

--- a/Sources/Pioneer/Extensions/Pioneer+Graphiti.swift
+++ b/Sources/Pioneer/Extensions/Pioneer+Graphiti.swift
@@ -63,6 +63,7 @@ public extension Pioneer {
     ///   - playground: Allowing playground
     ///   - validationRules: Validation rules to be applied before operation
     ///   - keepAlive: Keep alive internal in nanosecond, default to 12.5 sec, nil for disable
+    ///   - timeout: Timeout interval in nanosecond, default to 5 sec, nil for disable
     init(
         schema: Schema<Resolver, Context>,
         resolver: Resolver,
@@ -74,7 +75,8 @@ public extension Pioneer {
         introspection: Bool = true,
         playground: IDE = .graphiql,
         validationRules: Validations = .none,
-        keepAlive: UInt64? = 12_500_000_000
+        keepAlive: UInt64? = 12_500_000_000,
+        timeout: UInt64? = 5_000_000_000
     ) {
         self.init(
             schema: schema.schema,
@@ -86,7 +88,8 @@ public extension Pioneer {
             introspection: introspection,
             playground: playground,
             validationRules: validationRules,
-            keepAlive: keepAlive
+            keepAlive: keepAlive,
+            timeout: timeout
         )
     }
 }

--- a/Sources/Pioneer/Extensions/Pioneer+Graphiti.swift
+++ b/Sources/Pioneer/Extensions/Pioneer+Graphiti.swift
@@ -23,7 +23,7 @@ public extension Pioneer {
     init(
         schema: Schema<Resolver, Context>,
         resolver: Resolver,
-        contextBuilder: @escaping @Sendable (Request, Response) async throws -> Context,
+        contextBuilder: @Sendable @escaping (Request, Response) async throws -> Context,
         httpStrategy: HTTPStrategy = .queryOnlyGet,
         websocketProtocol: WebsocketProtocol = .graphqlWs,
         introspection: Bool = true,
@@ -57,6 +57,7 @@ public extension Pioneer {
     ///   - contextBuilder: Context builder from request
     ///   - httpStrategy: HTTP strategy
     ///   - websocketContextBuilder: Context builder for the websocket
+    ///   - websocketOnInit: Function to intercept websocket connection during the initialization phase
     ///   - websocketProtocol: Websocket sub-protocol
     ///   - introspection: Allowing introspection
     ///   - playground: Allowing playground
@@ -65,9 +66,10 @@ public extension Pioneer {
     init(
         schema: Schema<Resolver, Context>,
         resolver: Resolver,
-        contextBuilder: @escaping @Sendable (Request, Response) async throws -> Context,
+        contextBuilder: @Sendable @escaping (Request, Response) async throws -> Context,
         httpStrategy: HTTPStrategy = .queryOnlyGet,
-        websocketContextBuilder: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        websocketContextBuilder: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        websocketOnInit: @Sendable @escaping (ConnectionParams) async throws -> Void = { _ in },
         websocketProtocol: WebsocketProtocol = .graphqlWs,
         introspection: Bool = true,
         playground: IDE = .graphiql,

--- a/Sources/Pioneer/Extensions/Pioneer+RequestContext.swift
+++ b/Sources/Pioneer/Extensions/Pioneer+RequestContext.swift
@@ -17,6 +17,7 @@ public extension Pioneer where Context == Void {
     ///   - playground: Allowing playground
     ///   - validationRules: Validation rules to be applied before operation
     ///   - keepAlive: Keep alive internal in nanosecond, default to 12.5 sec, nil for disable
+    ///   - timeout: Timeout interval in nanosecond, default to 5 sec, nil for disable
     init(
         schema: Schema<Resolver, Void>,
         resolver: Resolver,
@@ -25,7 +26,8 @@ public extension Pioneer where Context == Void {
         introspection: Bool = true,
         playground: IDE = .graphiql,
         validationRules: Validations = .none,
-        keepAlive: UInt64? = 12_500_000_000
+        keepAlive: UInt64? = 12_500_000_000,
+        timeout: UInt64? = 5_000_000_000
     ) {
         self.init(
             schema: schema.schema,
@@ -37,7 +39,8 @@ public extension Pioneer where Context == Void {
             introspection: introspection,
             playground: playground,
             validationRules: validationRules,
-            keepAlive: keepAlive
+            keepAlive: keepAlive,
+            timeout: timeout
         )
     }
 }

--- a/Sources/Pioneer/Extensions/Vapor/Request+WebsocketContext.swift
+++ b/Sources/Pioneer/Extensions/Vapor/Request+WebsocketContext.swift
@@ -16,7 +16,7 @@ public extension Request {
     func defaultWebsocketContextBuilder<Context>(
         payload: ConnectionParams,
         gql: GraphQLRequest,
-        contextBuilder: @escaping @Sendable (Request, Response) async throws -> Context
+        contextBuilder: @Sendable @escaping (Request, Response) async throws -> Context
     ) async throws -> Context  {
         let uri = URI(
             scheme: url.scheme,

--- a/Sources/Pioneer/GraphQL/Extensions/GraphQLJSONEncoder+ContentEncoder.swift
+++ b/Sources/Pioneer/GraphQL/Extensions/GraphQLJSONEncoder+ContentEncoder.swift
@@ -1,0 +1,16 @@
+//
+//  GraphQLJSONEncoder+ContentEncoder.swift
+//  pioneer
+//
+//  Created by d-exclaimation on 11:30.
+//
+
+import Vapor
+import class GraphQL.GraphQLJSONEncoder
+
+extension GraphQLJSONEncoder: ContentEncoder {
+    public func encode<E>(_ encodable: E, to body: inout NIOCore.ByteBuffer, headers: inout NIOHTTP1.HTTPHeaders) throws where E : Encodable {
+        headers.contentType = .json
+        try body.writeBytes(self.encode(encodable))
+    }
+}

--- a/Sources/Pioneer/Http/Pioneer+Http.swift
+++ b/Sources/Pioneer/Http/Pioneer+Http.swift
@@ -80,7 +80,7 @@ extension Pioneer {
         do {
             let context = try await contextBuilder(req, res)
             let result = await executeOperation(for: gql, with: context, using: req.eventLoop)
-            try res.content.encode(result, using: GraphQLJSONEncoder())
+            try res.content.encode(result, using: encoder)
             return res
         } catch let error as AbortError {
             return try error.response(using: res)

--- a/Sources/Pioneer/Http/Pioneer+Http.swift
+++ b/Sources/Pioneer/Http/Pioneer+Http.swift
@@ -9,6 +9,7 @@ import Vapor
 import enum GraphQL.OperationType
 import enum GraphQL.Map
 import struct GraphQL.GraphQLError
+import class GraphQL.GraphQLJSONEncoder
 
 extension Pioneer {
     /// Apply middleware for `POST`
@@ -70,7 +71,7 @@ extension Pioneer {
         do {
             let context = try await contextBuilder(req, res)
             let result = await executeOperation(for: gql, with: context, using: req.eventLoop)
-            try res.content.encode(result)
+            try res.content.encode(result, using: GraphQLJSONEncoder())
             return res
         } catch let error as AbortError {
             return try error.response(using: res)

--- a/Sources/Pioneer/Pioneer.swift
+++ b/Sources/Pioneer/Pioneer.swift
@@ -33,6 +33,8 @@ public struct Pioneer<Resolver, Context> {
     public private(set) var validationRules: Validations
     /// Keep alive period
     public private(set) var keepAlive: UInt64?
+    /// Timeout period
+    public private(set) var timeout: UInt64?
 
     /// Internal running WebSocket actor for Pioneer
     internal var probe: Probe
@@ -48,7 +50,8 @@ public struct Pioneer<Resolver, Context> {
     ///   - introspection: Allowing introspection
     ///   - playground: Allowing playground
     ///   - validationRules: Validation rules to be applied before operation
-    ///   - keepAlive: Keep alive internal in nanosecond, default to 12.5 sec, nil for disable
+    ///   - keepAlive: Keep alive interval in nanosecond, default to 12.5 sec, nil for disable
+    ///   - timeout: Timeout interval in nanosecond, default to 5 sec, nil for disable
     public init(
         schema: GraphQLSchema,
         resolver: Resolver,
@@ -60,7 +63,8 @@ public struct Pioneer<Resolver, Context> {
         introspection: Bool = true,
         playground: IDE = .graphiql,
         validationRules: Validations = .none,
-        keepAlive: UInt64? = 12_500_000_000
+        keepAlive: UInt64? = 12_500_000_000,
+        timeout: UInt64? = 5_000_000_000
     ) {
         self.schema = schema
         self.resolver = resolver
@@ -72,6 +76,7 @@ public struct Pioneer<Resolver, Context> {
         self.playground = !introspection ? .disable : playground
         self.validationRules = validationRules
         self.keepAlive = keepAlive
+        self.timeout = timeout
 
 
         let proto: SubProtocol.Type = def {

--- a/Sources/Pioneer/Pioneer.swift
+++ b/Sources/Pioneer/Pioneer.swift
@@ -43,6 +43,7 @@ public struct Pioneer<Resolver, Context> {
     ///   - contextBuilder: Context builder from request
     ///   - httpStrategy: HTTP strategy
     ///   - websocketContextBuilder: Context builder for the websocket
+    ///   - websocketOnInit: Function to intercept websocket connection during the initialization phase
     ///   - websocketProtocol: Websocket sub-protocol
     ///   - introspection: Allowing introspection
     ///   - playground: Allowing playground
@@ -51,9 +52,10 @@ public struct Pioneer<Resolver, Context> {
     public init(
         schema: GraphQLSchema,
         resolver: Resolver,
-        contextBuilder: @escaping @Sendable (Request, Response) async throws -> Context,
+        contextBuilder: @Sendable @escaping (Request, Response) async throws -> Context,
         httpStrategy: HTTPStrategy = .queryOnlyGet,
-        websocketContextBuilder: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        websocketContextBuilder: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        websocketOnInit: @Sendable @escaping (ConnectionParams) async throws -> Void = { _ in },
         websocketProtocol: WebsocketProtocol = .graphqlWs,
         introspection: Bool = true,
         playground: IDE = .graphiql,

--- a/Sources/Pioneer/Streaming/Extension/AsyncEventStream+Future+GraphQLResult.swift
+++ b/Sources/Pioneer/Streaming/Extension/AsyncEventStream+Future+GraphQLResult.swift
@@ -41,9 +41,9 @@ extension AsyncSequence where Element == Future<GraphQL.GraphQLResult> {
     /// - Returns: The Task used to consume this AsyncSequence
     public func pipe<ActorType: Actor>(
         to sink: ActorType,
-        complete: @escaping @Sendable (ActorType) async -> Void,
-        failure: @escaping @Sendable (ActorType, Error) async -> Void,
-        next: @escaping @Sendable (ActorType, GraphQL.GraphQLResult) async -> Void
+        complete: @Sendable @escaping (ActorType) async -> Void,
+        failure: @Sendable @escaping (ActorType, Error) async -> Void,
+        next: @Sendable @escaping (ActorType, GraphQL.GraphQLResult) async -> Void
     ) -> Task<Void, Error> {
         Task.init {
             do {

--- a/Sources/Pioneer/Streaming/Extension/AsyncSequence+EventStream.swift
+++ b/Sources/Pioneer/Streaming/Extension/AsyncSequence+EventStream.swift
@@ -22,7 +22,7 @@ extension AsyncSequence {
     /// - Parameters:
     ///   - onTermination: onTermination callback
     public func toEventStream(
-        onTermination callback: @escaping @Sendable (Termination) -> Void
+        onTermination callback: @Sendable @escaping (Termination) -> Void
     ) -> EventStream<Element> {
         let stream = AsyncThrowingStream<Element, Error> { continuation in
             let task = Task.init {
@@ -56,7 +56,7 @@ extension AsyncSequence {
     ///   - onTermination: onTermination callback
     public func toEventStream(
         endValue: @escaping () -> Element,
-        onTermination callback: @escaping @Sendable (Termination) -> Void
+        onTermination callback: @Sendable @escaping (Termination) -> Void
     ) -> EventStream<Element> {
         let stream = AsyncThrowingStream<Element, Error> { continuation in
             let task = Task.init {
@@ -91,7 +91,7 @@ extension AsyncSequence {
     ///   - onTermination: onTermination callback
     public func toEventStream(
         initialValue: Element,
-        onTermination callback: @escaping @Sendable (Termination) -> Void
+        onTermination callback: @Sendable @escaping (Termination) -> Void
     ) -> EventStream<Element> {
         let stream = AsyncThrowingStream<Element, Error> { continuation in
             let task = Task.init {
@@ -127,7 +127,7 @@ extension AsyncSequence {
     public func toEventStream(
         initialValue: Element,
         endValue: @escaping () -> Element,
-        onTermination callback: @escaping @Sendable (Termination) -> Void
+        onTermination callback: @Sendable @escaping (Termination) -> Void
     ) -> EventStream<Element> {
         let stream = AsyncThrowingStream<Element, Error> { continuation in
             let task = Task.init {

--- a/Sources/Pioneer/Utils/Configuration.swift
+++ b/Sources/Pioneer/Utils/Configuration.swift
@@ -22,6 +22,8 @@ extension Pioneer {
         let httpStrategy: Pioneer<Resolver, Context>.HTTPStrategy 
         /// Websocket Context builder
         let websocketContextBuilder: @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context
+        /// Websocket handler function for initialization phase
+        let websocketOnInit: @Sendable (ConnectionParams) async throws -> Void
         /// Websocket sub-protocol
         let websocketProtocol: Pioneer<Resolver, Context>.WebsocketProtocol
         /// Allowing introspection
@@ -36,9 +38,10 @@ extension Pioneer {
         public init(
             schema: GraphQLSchema,
             resolver: Resolver,
-            contextBuilder: @escaping @Sendable (Request, Response) async throws -> Context,
+            contextBuilder: @Sendable @escaping (Request, Response) async throws -> Context,
             httpStrategy: HTTPStrategy = .queryOnlyGet,
-            websocketContextBuilder: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+            websocketContextBuilder: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+            websocketOnInit: @Sendable @escaping (ConnectionParams) async throws -> Void = { _ in },
             websocketProtocol: WebsocketProtocol = .graphqlWs,
             introspection: Bool = true,
             playground: IDE = .graphiql,
@@ -50,6 +53,7 @@ extension Pioneer {
             self.contextBuilder = contextBuilder
             self.httpStrategy = httpStrategy
             self.websocketContextBuilder = websocketContextBuilder
+            self.websocketOnInit = websocketOnInit
             self.websocketProtocol = websocketProtocol
             self.introspection = introspection
             self.playground = !introspection ? .disable : playground
@@ -67,6 +71,7 @@ public extension Pioneer {
             contextBuilder: config.contextBuilder, 
             httpStrategy: config.httpStrategy,
             websocketContextBuilder: config.websocketContextBuilder,
+            websocketOnInit: config.websocketOnInit,
             websocketProtocol: config.websocketProtocol,
             introspection: config.introspection,
             playground: config.playground,

--- a/Sources/Pioneer/Utils/Configuration.swift
+++ b/Sources/Pioneer/Utils/Configuration.swift
@@ -34,6 +34,8 @@ extension Pioneer {
         let validationRules: Validations
         /// Keep alive period
         let keepAlive: UInt64?
+        /// Timeout period
+        let timeout: UInt64?
 
         public init(
             schema: GraphQLSchema,
@@ -46,7 +48,8 @@ extension Pioneer {
             introspection: Bool = true,
             playground: IDE = .graphiql,
             validationRules: Validations = .none,
-            keepAlive: UInt64? = 12_500_000_000
+            keepAlive: UInt64? = 12_500_000_000,
+            timeout: UInt64? = 5_000_000_000
         ) {
             self.schema = schema
             self.resolver = resolver
@@ -59,6 +62,7 @@ extension Pioneer {
             self.playground = !introspection ? .disable : playground
             self.validationRules = validationRules
             self.keepAlive = keepAlive
+            self.timeout = timeout
         }
     }
 }
@@ -76,7 +80,8 @@ public extension Pioneer {
             introspection: config.introspection,
             playground: config.playground,
             validationRules: config.validationRules,
-            keepAlive: config.keepAlive
+            keepAlive: config.keepAlive,
+            timeout: config.timeout
         )
     }
 }

--- a/Sources/Pioneer/Utils/Configurations/Default.swift
+++ b/Sources/Pioneer/Utils/Configurations/Default.swift
@@ -21,8 +21,8 @@ public extension Pioneer.Config {
     static func `default`(
         using schema: GraphQLSchema, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
-        websocketContext: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
+        websocketContext: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
         validationRules: Pioneer<Resolver, Context>.Validations = .none,
         introspection: Bool = true
     ) -> Self {
@@ -50,7 +50,7 @@ public extension Pioneer.Config {
     static func `default`(
         using schema: GraphQLSchema, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
         validationRules: Pioneer<Resolver, Context>.Validations = .none,
         introspection: Bool = true
     ) -> Self {

--- a/Sources/Pioneer/Utils/Configurations/Detect.swift
+++ b/Sources/Pioneer/Utils/Configurations/Detect.swift
@@ -56,8 +56,8 @@ public extension Pioneer.Config {
     static func detect(
         using schema: GraphQLSchema, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
-        websocketContext: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
+        websocketContext: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
         validationRules: Pioneer<Resolver, Context>.Validations = .none
     ) throws -> Self {
         guard let strategy = Environment.get("PIONEER_HTTP_STRATEGY") else {

--- a/Sources/Pioneer/Utils/Configurations/HttpOnly.swift
+++ b/Sources/Pioneer/Utils/Configurations/HttpOnly.swift
@@ -32,7 +32,7 @@ public extension Pioneer.Config {
     static func simpleHttpOnly(
         using schema: GraphQLSchema, 
         with resolver: Resolver, 
-        and contextBuilder: @escaping @Sendable (Request, Response) async throws -> Context,
+        and contextBuilder: @Sendable @escaping (Request, Response) async throws -> Context,
         allowing introspection: Bool = true
     ) -> Self {
         .init(
@@ -61,7 +61,7 @@ public extension Pioneer.Config {
     static func httpOnly(
         using schema: GraphQLSchema, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
         httpStrategy: Pioneer<Resolver, Context>.HTTPStrategy,
         playground: Pioneer<Resolver, Context>.IDE,
         validationRules: Pioneer<Resolver, Context>.Validations = .none,

--- a/Sources/Pioneer/Utils/Configurations/Secured.swift
+++ b/Sources/Pioneer/Utils/Configurations/Secured.swift
@@ -21,8 +21,8 @@ public extension Pioneer.Config {
     static func secured(
         using schema: GraphQLSchema, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
-        websocketContext: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
+        websocketContext: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
         validationRules: Pioneer<Resolver, Context>.Validations = .none,
         introspection: Bool = true
     ) -> Self {
@@ -50,7 +50,7 @@ public extension Pioneer.Config {
     static func secured(
         using schema: GraphQLSchema, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
         validationRules: Pioneer<Resolver, Context>.Validations = .none,
         introspection: Bool = true
     ) -> Self {

--- a/Sources/Pioneer/Utils/Configurations/WsOnly.swift
+++ b/Sources/Pioneer/Utils/Configurations/WsOnly.swift
@@ -33,7 +33,7 @@ public extension Pioneer.Config {
     static func simpleWsOnly(
         using schema: GraphQLSchema, 
         with resolver: Resolver, 
-        and contextBuilder: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        and contextBuilder: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
         allowing introspection: Bool = true
     ) -> Self {
         .init(
@@ -65,7 +65,8 @@ public extension Pioneer.Config {
     static func wsOnly(
         using schema: GraphQLSchema,
         resolver: Resolver,
-        context: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        context: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        onInit: @Sendable @escaping (ConnectionParams) async throws -> Void = { _ in },
         websocketProtocol: Pioneer<Resolver, Context>.WebsocketProtocol,
         playground: Pioneer<Resolver, Context>.IDE,
         validationRules: Pioneer<Resolver, Context>.Validations = .none,
@@ -82,6 +83,7 @@ public extension Pioneer.Config {
             }, 
             httpStrategy: .onlyPost,
             websocketContextBuilder: context, 
+            websocketOnInit: onInit,
             websocketProtocol: websocketProtocol, 
             introspection: introspection, 
             playground: playground,

--- a/Sources/Pioneer/Utils/Extensions/Graphiti+Config.swift
+++ b/Sources/Pioneer/Utils/Extensions/Graphiti+Config.swift
@@ -30,8 +30,8 @@ public extension Pioneer.Config {
     static func detect(
         using schema: Schema<Resolver, Context>, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
-        websocketContext: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
+        websocketContext: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context
     ) throws -> Self {
         try .detect(using: schema.schema, resolver: resolver, context: context, websocketContext: websocketContext)
     }
@@ -48,8 +48,8 @@ public extension Pioneer.Config {
     static func secured(
         using schema: Schema<Resolver, Context>, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
-        websocketContext: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
+        websocketContext: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
         introspection: Bool = true
     ) -> Self {
         .secured(
@@ -71,7 +71,7 @@ public extension Pioneer.Config {
     static func secured(
         using schema: Schema<Resolver, Context>, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
         introspection: Bool = true
     ) -> Self {
         .secured(
@@ -94,8 +94,8 @@ public extension Pioneer.Config {
     static func `default`(
         using schema: Schema<Resolver, Context>, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
-        websocketContext: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
+        websocketContext: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
         introspection: Bool = true
     ) -> Self {
         .default(
@@ -117,7 +117,7 @@ public extension Pioneer.Config {
     static func `default`(
         using schema: Schema<Resolver, Context>, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
         introspection: Bool = true
     ) -> Self {
         .default(
@@ -142,7 +142,7 @@ public extension Pioneer.Config {
     static func httpOnly(
         using schema: Schema<Resolver, Context>, 
         resolver: Resolver, 
-        context: @escaping @Sendable (Request, Response) async throws -> Context,
+        context: @Sendable @escaping (Request, Response) async throws -> Context,
         httpStrategy: Pioneer<Resolver, Context>.HTTPStrategy,
         playground: Pioneer<Resolver, Context>.IDE,
         introspection: Bool = true  
@@ -168,7 +168,7 @@ public extension Pioneer.Config {
     static func simpleHttpOnly(
         using schema: Schema<Resolver, Context>, 
         with resolver: Resolver, 
-        and contextBuilder: @escaping @Sendable (Request, Response) async throws -> Context,
+        and contextBuilder: @Sendable @escaping (Request, Response) async throws -> Context,
         allowing introspection: Bool = true
     ) -> Self {
         .simpleHttpOnly(using: schema.schema, with: resolver, and: contextBuilder, allowing: introspection)
@@ -187,7 +187,7 @@ public extension Pioneer.Config {
     static func wsOnly(
         using schema: Schema<Resolver, Context>,
         resolver: Resolver,
-        context: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        context: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
         websocketProtocol: Pioneer<Resolver, Context>.WebsocketProtocol,
         playground: Pioneer<Resolver, Context>.IDE,
         introspection: Bool = true
@@ -213,7 +213,7 @@ public extension Pioneer.Config {
     static func simpleWsOnly(
         using schema: Schema<Resolver, Context>, 
         with resolver: Resolver, 
-        and contextBuilder: @escaping @Sendable (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
+        and contextBuilder: @Sendable @escaping (Request, ConnectionParams, GraphQLRequest) async throws -> Context,
         allowing introspection: Bool = true
     ) -> Self {
         .simpleWsOnly(using: schema.schema, with: resolver, and: contextBuilder, allowing: introspection)

--- a/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
+++ b/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
@@ -175,7 +175,7 @@ extension Pioneer {
 }
 
 
-@discardableResult func setInterval(delay: UInt64?, _ block: @escaping @Sendable () throws -> Void) -> Task<Void, Error>? {
+@discardableResult func setInterval(delay: UInt64?, _ block: @Sendable @escaping () throws -> Void) -> Task<Void, Error>? {
     guard let delay = delay else {
         return nil
     }

--- a/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
+++ b/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
@@ -46,9 +46,6 @@ extension Pioneer {
 
             /// Scheduled a timeout for any connection
             let timeout = setTimeout(delay: 5_000_000_000) {
-                if ws.isClosed {
-                    throw Abort(.conflict, reason: "WebSocket closed before any termination")
-                }
                 try await ws.close(code: .graphqlInitTimeout)
                 keepAlive?.cancel()
             }
@@ -209,7 +206,7 @@ extension Pioneer {
     } 
     return Task {
         try await Task.sleep(nanoseconds: delay)
-        guard Task.isCancelled else {
+        guard !Task.isCancelled else {
             return
         }
         try await block()

--- a/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
+++ b/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
@@ -107,6 +107,7 @@ extension Pioneer {
         case .terminate:
             await probe.disconnect(for: pid)
             keepAlive?.cancel()
+            timeout?.cancel()
             try? await ws.close(code: .goingAway).get()
 
         // Start -> Long running operation

--- a/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
+++ b/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
@@ -170,7 +170,7 @@ extension Pioneer {
             // Deallocation of resources
             await probe.disconnect(for: pid)
             keepAlive?.cancel()
-            try? await ws.close(code: .policyViolation).get()
+            try? await ws.close(code: .graphqlInvalid).get()
 
         case .ignore:
             break

--- a/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
+++ b/Sources/Pioneer/WebSocket/Pioneer+WebSocket.swift
@@ -37,7 +37,7 @@ extension Pioneer {
             ws.sendPing()
                 
             /// Scheduled keep alive message interval
-            let keepAlive = setInterval(delay: 12_500_000_000) {
+            let keepAlive = setInterval(delay: keepAlive) {
                 if ws.isClosed {
                     throw Abort(.conflict, reason: "WebSocket closed before any termination")
                 }
@@ -45,7 +45,7 @@ extension Pioneer {
             }
 
             /// Scheduled a timeout for any connection
-            let timeout = setTimeout(delay: 5_000_000_000) {
+            let timeout = setTimeout(delay: timeout) {
                 try await ws.close(code: .graphqlInitTimeout)
                 keepAlive?.cancel()
             }

--- a/Sources/Pioneer/WebSocket/Probe/Drone/Drone.swift
+++ b/Sources/Pioneer/WebSocket/Probe/Drone/Drone.swift
@@ -146,13 +146,5 @@ extension Pioneer {
                 operationName: gql.operationName
             )
         }
-
-        deinit {
-            tasks.forEach { (oid, task) in
-                let message = GraphQLMessage(id: oid, type: proto.complete)
-                process.send(message.jsonString)
-                task.cancel()
-            }
-        }
     }
 }

--- a/Sources/Pioneer/WebSocket/Probe/Probe.swift
+++ b/Sources/Pioneer/WebSocket/Probe/Probe.swift
@@ -71,7 +71,6 @@ extension Pioneer {
         /// Long running operation require its own actor, thus initialing one if there were none prior
         func start(for pid: UUID, with oid: String, given gql: GraphQLRequest) async {
             guard let process = clients[pid] else { 
-                await deny(process: process, with: error)
                 return
             }
 
@@ -90,7 +89,6 @@ extension Pioneer {
         /// Short lived operation is processed immediately and pipe back later
         func once(for pid: UUID, with oid: String, given gql: GraphQLRequest) async {
             guard let process = clients[pid] else { 
-                await deny(process: process, with: error)
                 return
             }
 
@@ -153,7 +151,7 @@ extension Pioneer {
             let err = GraphQLMessage.errors(type: proto.error, [error.graphql])
             process.send(err.jsonString)
             process.keepAlive?.cancel()
-            await process.close(code: .policyViolation) 
+            await process.close(code: .graphqlNotAuthorized) 
         } 
     }
 }

--- a/Sources/Pioneer/WebSocket/Protocol/SubProtocol.swift
+++ b/Sources/Pioneer/WebSocket/Protocol/SubProtocol.swift
@@ -6,6 +6,7 @@
 //
 
 import struct Foundation.Data
+import enum NIOWebSocket.WebSocketErrorCode
 import enum GraphQL.Map
 
 /// GraphQL Over Websocket sub-protocol
@@ -45,5 +46,15 @@ extension SubProtocol {
         case .subscription:
             return .start(oid: oid, gql: gql)
         }
+    }
+}
+
+extension WebSocketErrorCode {
+    static var graphqlNotAuthorized: WebSocketErrorCode {
+        .init(codeNumber: 4401)
+    }
+    
+    static var graphqlInitTimeout: WebSocketErrorCode {
+        .init(codeNumber: 4408)
     }
 }

--- a/Sources/Pioneer/WebSocket/Protocol/SubProtocol.swift
+++ b/Sources/Pioneer/WebSocket/Protocol/SubProtocol.swift
@@ -57,4 +57,8 @@ extension WebSocketErrorCode {
     static var graphqlInitTimeout: WebSocketErrorCode {
         .init(codeNumber: 4408)
     }
+
+    static var graphqlInvalid: WebSocketErrorCode {
+        .init(codeNumber: 4400)
+    }
 }

--- a/Sources/Pioneer/WebSocket/Shared/Process.swift
+++ b/Sources/Pioneer/WebSocket/Shared/Process.swift
@@ -21,12 +21,21 @@ extension Pioneer {
         var payload: ConnectionParams
         /// Request attached to this process
         var req: Request
+        /// KeepAlive Task
+        var keepAlive: Task<Void, Error>?
 
-        init(id: UUID = UUID(), ws: ProcessingConsumer, payload: ConnectionParams, req: Request) {
+        init(
+            id: UUID = UUID(), 
+            ws: ProcessingConsumer, 
+            payload: ConnectionParams, 
+            req: Request, 
+            keepAlive: Task<Void, Error>? = nil
+        ) {
             self.id = id
             self.ws = ws
             self.payload = payload
             self.req = req
+            self.keepAlive = keepAlive
         }
 
         /// Send a text message

--- a/Tests/PioneerTests/ActorTests/ProbeTests.swift
+++ b/Tests/PioneerTests/ActorTests/ProbeTests.swift
@@ -73,7 +73,6 @@ final class ProbeTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 1_000_000)
         
         let results = await con.waitAll()
-        print(results)
         guard let _ = results.first(where: { $0.contains("\"complete\"") && $0.contains("\"1\"") }) else {
             return XCTFail("No completion")
         }

--- a/Tests/PioneerTests/ActorTests/ProbeTests.swift
+++ b/Tests/PioneerTests/ActorTests/ProbeTests.swift
@@ -27,7 +27,7 @@ final class ProbeTests: XCTestCase {
             AsyncStream.just("hello").toEventStream()
         }
     }
-    
+
     /// Setup the GraphQL schema and Probe, then return the Probe
     func setup() throws -> Pioneer<Resolver, Void>.Probe {
         let schema = try Schema<Resolver, Void>.init {
@@ -43,7 +43,12 @@ final class ProbeTests: XCTestCase {
             schema: schema,
             resolver: Resolver(),
             proto: SubscriptionTransportWs.self,
-            websocketContextBuilder: { _, _, _ in }
+            websocketContextBuilder: { _, _, _ in },
+            websocketOnInit: { payload in
+                guard case .some = payload else {
+                    throw Abort(.ok)
+                }
+            }
         )
     }
 
@@ -51,7 +56,7 @@ final class ProbeTests: XCTestCase {
     func consumer() -> (Pioneer<Resolver, Void>.Process, TestConsumer)  {
         let req = Request.init(application: app, on: app.eventLoopGroup.next())
         let consumer = TestConsumer.init(group: app.eventLoopGroup.next())
-        return (.init(ws: consumer, payload: nil, req: req), consumer)
+        return (.init(ws: consumer, payload: [:], req: req), consumer)
     }
 
     /// Probe
@@ -143,5 +148,19 @@ final class ProbeTests: XCTestCase {
         }
         XCTAssert(!errors.isEmpty)
         await probe.disconnect(for: process.id)
+    }
+
+    /// Probe
+    /// 1. Should not accept if websocketOnInit throws an error
+    func testOnInit() async throws {
+        let probe = try setup()
+        let req = Request.init(application: app, on: app.eventLoopGroup.next())
+        let consumer = TestConsumer.init(group: app.eventLoopGroup.next())
+        await probe.connect(with: .init(ws: consumer, payload: nil, req: req))
+
+        let results = await consumer.waitAll()
+        guard let _ = results.first(where: { $0.contains("\"error\"") }) else {
+            return XCTFail("No result")
+        }
     }
 }


### PR DESCRIPTION
### Description
- Added a way to intercept WebSocket connection during the initialisation phase.
- Updated `Process` to take in the `keepAlive` task.
- Updated `Probe` to run the `onInit` function during the connection and close a connection if that function return an error
- Updated `Pioneer` to use `GraphQLJSONEncoder` to encode HTTP responses
- Updated `Pioneer.httpHandler` to take a custom `ContentEncoder`
- Added timeout to any unacknowledged WebSocket connection