### PR TITLE
v1: Integration support

### DIFF
--- a/Documentation/features/graphql-over-http.md
+++ b/Documentation/features/graphql-over-http.md
@@ -11,7 +11,7 @@ GraphQL spec define how a GraphQL operation is supposed to be performed through 
 
 Pioneer have a feature to specify how operations can be handled through HTTP. There are situations where a GraphQL API should not perform something like mutations through HTTP **GET**, or the user of the library preffered just using HTTP **POST** for all operations (excluding subscriptions).
 
-[HTTPStrategy](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/httpstrategy-swift.enum) is a enum that can be passed in as one of the arguments when initializing Pioneer to specify which approach you prefer.
+[HTTPStrategy](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpstrategy-swift.enum) is a enum that can be passed in as one of the arguments when initializing Pioneer to specify which approach you prefer.
 
 ```swift #3
 Pioneer(
@@ -62,7 +62,7 @@ Pioneer uses the same mechanic to prevent these types of attacks as [Apollo Serv
 If you set the http strategy to `.queryOnlyGet` or `.onlyPost` and as long as you ensure that only mutations can have side effects, you are somewhat protected from the "side effects" aspect of CSRFs even without enabling CSRF protection.
 !!!
 
-To enable it, just change the [HTTPStrategy](#http-strategy) to [.csrfPrevention](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/httpstrategy-swift.enum/csrfprevention), which will add additional restrictions to any GraphQL request going through HTTP.
+To enable it, just change the [HTTPStrategy](#http-strategy) to [.csrfPrevention](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpstrategy-swift.enum/csrfprevention), which will add additional restrictions to any GraphQL request going through HTTP.
 
 ```swift
 let server = Pioneer(

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -314,7 +314,7 @@ try app.run()
 
 ### Pioneer as Vapor middleware
 
-Finally, apply Pioneer to Vapor as a [middleware](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/vapormiddleware).
+Finally, apply Pioneer to Vapor as a [middleware](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/vapormiddleware).
 
 ```swift #18-25 main.swift
 import Pioneer

--- a/Documentation/v1/migrating.md
+++ b/Documentation/v1/migrating.md
@@ -128,30 +128,32 @@ In [**v1**](/), Pioneer will use the same path for all of those, and will instea
 ### New defaults
 
 Pioneer will now defaults to 
-- [.csrfPrevention](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/httpstrategy-swift.enum/csrfprevention) for its [HTTPStrategy](/features/graphql-over-http/#http-strategy)
-- [.sandbox](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/ide/sandbox) for its [WebSocket Protocol](/features/graphql-over-websocket/#websocket-subprotocol)
+- [.csrfPrevention](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpstrategy-swift.enum/csrfprevention) for its [HTTPStrategy](/features/graphql-over-http/#http-strategy)
+- [.sandbox](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/ide/sandbox) for its [WebSocket Protocol](/features/graphql-over-websocket/#websocket-subprotocol)
 - `30` seconds for the keep alive interval for GraphQL over WebSocket
 
 ### WebSocket callbacks
 
 Some WebSocket callbacks are now exposed as functions in Pioneer. These can be used to add a custom WebSocket layer.
 
-- [.receiveMessage](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer)
+- [.receiveMessage](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer)
 	- Callback to be called for each WebSocket message
-- [.initialiseClient](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer)
+- [.initialiseClient](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer)
 	- Callback after getting a GraphQL over WebSocket initialisation message according to the given protocol
-- [.executeLongOperation](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer)
+- [.executeLongOperation](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer)
 	- Callback to run long running operation using Pioneer
-- [.executeShortOperation](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer)
+- [.executeShortOperation](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer)
 	- Callback to run short lived operation using Pioneer
 
 ### Pioneer capabilities
 
 Some other capabilities of Pioneer is now exposed:
 
-- [.allowed](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/allowed(from:allowing:)), Check if a GraphQL request is allowed given the allowed list of operations
+- [.allowed](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/allowed(from:allowing:)), Check if a GraphQL request is allowed given the allowed list of operations
 
-- [.csrfVulnerable](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/csrfvulnerable(given:)), Check if the headers given show signs of CSRF and XS-Search vulnerability
+- [.csrfVulnerable](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/csrfvulnerable(given:)), Check if the headers given show signs of CSRF and XS-Search vulnerability
+
+- [.executeHTTPGraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/csrfvulnerable(given:)), Execute an operation for a given [HTTPGraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpgraphqlrequest) and returns  [HTTPGraphQLResponse](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpgraphqlresponse)
 
 ### ConnectionParams to Payload
 
@@ -172,7 +174,7 @@ These are simplified list of things that changed
 - Manually perform CSRF vulnerability checks and HTTP Strategy check
 - Uses 1 path for all types of operations
 - Open opportunity for other web framework integrations
-- Changed defaults to [.csrfPrevention](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/httpstrategy-swift.enum/csrfprevention) for HTTP strategy, [.graphqlWs](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/websocketprotocol-swift.enum/graphqlws) for WebSocket protocol, and [.sandbox](https://swiftpackageindex.com/d-exclaimation/pioneer/0.10.1/documentation/pioneer/pioneer/ide/sandbox) for GraphQL IDE.
+- Changed defaults to [.csrfPrevention](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpstrategy-swift.enum/csrfprevention) for HTTP strategy, [.graphqlWs](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/websocketprotocol-swift.enum/graphqlws) for WebSocket protocol, and [.sandbox](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/ide/sandbox) for GraphQL IDE.
 
 [!badge variant="danger" text="Removed"](#tradeoff)
 

--- a/Documentation/web-frameworks/integration.md
+++ b/Documentation/web-frameworks/integration.md
@@ -20,6 +20,178 @@ Exisiting first-party of community maintained integrations for Pioneer:
 This section is for *authors* of web frameworks integrations. Before building a new integration, it's recommended seeing if there's an [integration](#open-source-integrations) for your framework of choice that suits your needs
 !!!
 
-!!!danger
-Incomplete
-!!!
+### Implementing GraphQL over HTTP 
+
+First, the HTTP layer. Pioneer provide a method [.executeHTTPGraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneerexecutehttpgraphqlrequest(for:with:using)) which is the base layer of an GraphQL would look like HTTP handler.
+
+All that is missing to use that method is translating the web-framework native request object into [HTTPGraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpgraphqlrequest).
+
+#### Mapping into [HTTPGraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpgraphqlrequest)
+
+[HTTPGraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpgraphqlrequest) only require 3 properties: the GraphQLRequest object, the HTTP headers, and the HTTP method.
+
+```swift #2-4
+struct HTTPGraphQLRequest {
+    var request: GraphQLRequest
+    var headers: HTTPHeaders
+    var method: HTTPMethod
+}
+```
+
+The important part is parsing into [GraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/graphqlrequest). A recommended approach in parsing is:
+
+1. Parse [GraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/graphqlrequest) from the body of a request. (Usually for **POST**)
+2. If it's in the body, get the values from the query/search parameters. (Usually for **GET**)
+    - The query string should be under `query`
+    - The operation name should be under `operationName`
+    - The variables should be under `variables` as JSON string
+        - This is probably percent encoded, and also need to be parse into `[String: Map]?` if available
+    - As long the query string is accessible, the request is not malformed and we can construct a [GraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/graphqlrequest) using that.
+3. If [GraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/graphqlrequest) can't be retreive by both approach 1 and 2, the request is malformed and the response should have status code of 404 Bad Request.
+
+==- Example
+
+```swift #
+import class WebFramework.Request
+
+extension Request {
+    var graphql: HTTPGraphQLRequest? {
+        switch (method) {
+            // Parsing from body for POST
+            case .post:
+                guard let gql = try? JSONDecoder().decode(GraphQLRequest.self, from: self.body) else {
+                    return nil
+                }
+                return .init(request: gql, headers: headers, method: method)
+
+            // Parsing from query/search params for GET
+            case .get:
+                guard let query = self.search["query"] else {
+                    return nil
+                }
+                let operationName = self.search["operationName"]
+                let variables = self.search["variables"]?
+                    .removingPercentEncoding
+                    .flatMap {
+                        $0.data(using: .utf8)
+                    }
+                    .flatMap {
+                        try? JSONDecoder().decode([String: Map].self, from: $0)
+                    }
+                let gql = GraphQLRequest(query: query, operationName: operationName, variables: variables)
+                return .init(request: gql, headers: headers, method: method)
+            
+            default:
+                return nil
+        }
+    }
+}
+```
+
+===
+
+#### Getting the context
+
+It's important that the context should be computed / derived for each request. By convention, it's best to allow user of the integration to compute the context from the request and the response object of the web-framework.
+
+If the compute function is allowed to be asynchronous, make sure to make it `Sendable` conformance by adding the `@Sendable` function wrapper.
+
+==- Example
+
+```swift #
+import class WebFramework.Request
+import class WebFramework.Response
+import struct Pioneer.Pioneer
+
+extension Pioneer {
+    typealias WebFrameworkHTTPContext = @Sendable (Request, Response) async throws -> Context
+}
+```
+
+===
+
+#### Executing and using [HTTPGraphQLResponse](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpgraphqlresponse)
+
+Once, there is a way to retreive [HTTPGraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpgraphqlrequest) and the context. All is needed is to execute the request and mapped the [HTTPGraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer/httpgraphqlresponse) into the web-framework response object.
+
+```swift #2-3
+struct HTTPGraphQLResponse {
+    var result: GraphQLResult
+    var status: HTTPResponseStatus
+}
+```
+
+==- Example
+
+```swift #9-14,16-19,23-25
+import class WebFramework.Request
+import class WebFramework.Response
+import struct Pioneer.Pioneer
+import struct GraphQL.GraphQLJSONEncoder
+
+extension Pioneer {
+    public func httpHandler(req: Request, context: @escaping WebFrameworkHTTPContext) async throws -> Response {
+        do {
+            // Parsing HTTPGraphQLRequest and Context 
+            guard let httpreq = req.graphql else {
+                return Response(status: .badRequest)
+            }
+            let res = Response()
+            let context = try await context(req, res)
+
+            // Executing into GraphQLResult
+            let httpRes = await executeHTTPGraphQLRequest(for: httpreq, with: context, using: req.eventLoop)
+            res.body = try GraphQLJSONEncoder().encode(httpres.result)
+            res.status = httpRes.status
+
+            return res
+        } catch {
+            // Format error caught into GraphQLResult
+            let body = try GraphQLJSONEncoder().encode(GraphQLResult(data: nil, errors: [.init(error)]))
+            return Response(status: .internalServerError, body: body)
+        }
+    }
+}
+```
+===
+
+### Implementing GraphQL IDE 
+
+This is part is relatively simple, send back the web-framework response that contains the HTML for the given IDE or a redirect if the IDE was set to be a redirect. 
+
+The HTML for each type of IDE are available as computed properties of Pioneer. The URL for the Cloud IDEs are accessible property.
+
+All that is needed is to serve this HTML and redirect if the IDE option is a redirect using the url given.
+
+==- Example
+
+```swift #7-15
+import class WebFramework.Request
+import class WebFramework.Response
+import struct Pioneer.Pioneer
+
+extension Pioneer {
+    func ideHandler(req: Request) -> Response {
+        switch (playground) {
+            case .sandbox:
+                return serve(html: embeddedSandboxHtml)
+            case .graphiql:
+                return serve(html: graphiqlHtml)
+            case .playground:
+                return serve(html: playgroundHtml)
+            case .redirect(to: let cloud):
+                return Response(status: .permanentRedirect, redirect: cloud.url)
+        }
+    }
+
+    func serve(html: String) -> Response {
+        Response(
+            status: .ok,
+            headers: ["Content-Type": "text/html"],
+            body: html.data(using: .utf8)
+        )
+    }
+}
+```
+
+===

--- a/Documentation/web-frameworks/integration.md
+++ b/Documentation/web-frameworks/integration.md
@@ -255,7 +255,7 @@ In order for Pioneer to use the web-framework specific implementation of WebSock
 
 ==- Example
 
-```swift #3-5,7-9
+```swift #5-7,9-11
 import enum NIOWebSocket.WebSocketErrorCode
 import class WebFramework.WebSocket
 

--- a/Documentation/web-frameworks/integration.md
+++ b/Documentation/web-frameworks/integration.md
@@ -161,7 +161,7 @@ This is part is relatively simple, send back the web-framework response that con
 
 The HTML for each type of IDE are available as computed properties of Pioneer. The URL for the Cloud IDEs are accessible property.
 
-All that is needed is to serve this HTML and redirect if the IDE option is a redirect using the url given.
+All that is needed is to serve this HTML and redirect if the IDE option is a redirect using the URL given.
 
 ==- Example
 
@@ -195,3 +195,9 @@ extension Pioneer {
 ```
 
 ===
+
+### Implemeting GraphQL over WebSocket
+
+!!!danger
+**TODO**: This section has not been written yet
+!!!

--- a/Documentation/web-frameworks/integration.md
+++ b/Documentation/web-frameworks/integration.md
@@ -290,7 +290,7 @@ After the upgrade is done, there's only a few things to do:
 
 ==- Example
 
-```swift #
+```swift #7-15,24,27-28,31-56,59-64
 import class WebFramework.Request
 import class WebFramework.Response
 import class WebFramework.WebSocket
@@ -316,9 +316,11 @@ extension Pioneer {
     ) -> Void {
         let cid = UUID()
 
+        // Keep alive and timeout task
         let keepAlive = keepAlive(using: ws)
         let timeout = timeout(using: ws, keepAlive: keepAlive)
 
+        // Consuming incoming message
         let receiving = Task {
             let stream = AsyncStream(String.self) { con in 
                 ws.onMessage(con.yield)
@@ -346,6 +348,7 @@ extension Pioneer {
             }
         }
 
+        // Closing task
         Task {
             try await ws.onClose.get()
             receiving.cancel()

--- a/Sources/Pioneer/Http/HTTPGraphQL.swift
+++ b/Sources/Pioneer/Http/HTTPGraphQL.swift
@@ -1,0 +1,34 @@
+//
+//  GraphQLResponse.swift
+//  pioneer
+//
+//  Created by d-exclaimation on 22:16.
+//
+
+import enum NIOHTTP1.HTTPResponseStatus
+import enum NIOHTTP1.HTTPMethod
+import struct NIOHTTP1.HTTPHeaders
+import struct GraphQL.GraphQLResult
+
+extension Pioneer {
+    /// HTTP-based GraphQL Response
+    public struct HTTPGraphQLResponse {
+        /// GraphQL Result for this response
+        public var result: GraphQLResult
+
+        /// HTTP status code for this response
+        public var status: HTTPResponseStatus
+    }
+
+    /// HTTP-based GraphQL request
+    public struct HTTPGraphQLRequest {
+        /// GraphQL Request for this request
+        public var request: GraphQLRequest
+
+        /// HTTP headers given in this request 
+        public var headers: HTTPHeaders
+
+        /// HTTP method for this request
+        public var method: HTTPMethod
+    }
+}

--- a/Sources/Pioneer/Http/IDE.swift
+++ b/Sources/Pioneer/Http/IDE.swift
@@ -31,7 +31,7 @@ extension Pioneer {
             case bananaCakePop
 
             /// URL for Cloud-based IDE
-            var url: String {
+            public var url: String {
                 switch (self) {
                     case .apolloSandbox:
                         return "https://studio.apollographql.com/sandbox/explorer"
@@ -40,10 +40,11 @@ extension Pioneer {
                 }
             }
         }
+
     }
         
     /// GraphQL Playground HTML
-    internal var playgroundHtml: String {
+    public var playgroundHtml: String {
         let graphqlPlayground = """
         <!DOCTYPE html>
         <html>
@@ -114,7 +115,7 @@ extension Pioneer {
     }
 
     /// GraphiQL HTML
-    internal var graphiqlHtml: String {
+    public var graphiqlHtml: String {
         let fetcher: String = def {
             switch websocketProtocol {
             case .subscriptionsTransportWs:
@@ -230,7 +231,7 @@ extension Pioneer {
     }
     
     /// Embedded Apollo Sandbox HTML
-    internal var embeddedSandboxHtml: String {
+    public var embeddedSandboxHtml: String {
         """
         <!DOCTYPE html>
         <html>

--- a/Sources/Pioneer/Vapor/WebSocket/Pioneer+WebSocket.swift
+++ b/Sources/Pioneer/Vapor/WebSocket/Pioneer+WebSocket.swift
@@ -42,17 +42,9 @@ extension Pioneer {
     func onUpgrade(req: Request, ws: WebSocket, context: @escaping VaporWebSocketContext, guard: @escaping VaporWebSocketGuard) -> Void {
         let cid = UUID()
 
-        let keepAlive = setInterval(delay: keepAlive) {
-            if ws.isClosed {
-                throw Abort(.conflict, reason: "WebSocket closed before termination")
-            }
-            ws.send(websocketProtocol.keepAliveMessage)
-        }
+        let keepAlive = keepAlive(using: ws)
 
-        let timeout = setTimeout(delay: timeout) {
-            try await ws.close(code: .graphqlInitTimeout)
-            keepAlive?.cancel()
-        }
+        let timeout = timeout(using: ws, keepAlive: keepAlive)
 
         // Task for consuming WebSocket messages to avoid cyclic references and provide cleaner code
         let receiving = Task {

--- a/Sources/Pioneer/WebSocket/Common/Pioneer+WebSocketable.swift
+++ b/Sources/Pioneer/WebSocket/Common/Pioneer+WebSocketable.swift
@@ -1,0 +1,27 @@
+//
+//  Pioneer+WebSocketable.swift
+//  pioneer
+//
+//  Created by d-exclaimation on 15:38.
+//
+
+import enum NIOWebSocket.WebSocketErrorCode
+
+public extension Pioneer {
+    /// Create a WebSocket connection ping / keep alive interval given the configuration
+    /// - Parameter io: any WebSocket output
+    func keepAlive(using io: WebSocketable) -> Task<Void, Error>? {
+        setInterval(delay: keepAlive) {
+            io.out(websocketProtocol.keepAliveMessage)
+        }
+    }
+
+    /// Create a WebSocket connectiontimeout given the configuration
+    /// - Parameter io: any WebSocket output
+    func timeout(using io: WebSocketable, keepAlive: Task<Void, Error>? = nil) -> Task<Void, Error>? {
+        setTimeout(delay: timeout) {
+            try await io.terminate(code: .graphqlInitTimeout)
+            keepAlive?.cancel()
+        }
+    }
+}


### PR DESCRIPTION
First stable release of Pioneer. Pioneer have been under [v0.x](https://github.com/d-exclaimation/pioneer/releases/tag/0.10.1) for a while and it has shown little major issues. This brings a bit more confidence for me to start introducing major improvements and changes.

This pull request is all about finishing up Pioneer **v1** by making sure it is easy and straightforward to built integrations.

This is a continuation of other **v1** pull requests:
- #92 
- #93 

Once all **v1** pull request have been merged, I am hoping to release **v1.0.0-rc.1** or **v1.0.0-beta** which will be available to use and play with (hopefully shine some light into uncaught issues). If no major issue come up, **v1.0.0** should be released soon after.

### Motivation

One of the goal is to allow more Web frameworks integrations. Vapor is a great Web framework, but similarly to [Apollo Server](https://www.apollographql.com/docs/apollo-server/integrations/integration-index/), Pioneer should not strictly restrict itself to one framework. 
At some point (possibly **v2**), Pioneer and its Vapor integration would be separate packages which allow user of the library to use other options if they see fit.

Another goal is catch up to [Apollo Server v4](https://www.apollographql.com/docs/apollo-server/migration) which have significant changes especially on the API of the library.

### Changes

- [x] GraphQL over HTTP integration documentation
- [x] GraphQL IDE integration documentation
- [x] GraphQL over WebSocket integration documentation
- [x] HTTPGraphQLRequest and HTTPGraphQLResponse  