### PR TITLE
v1: Standalone

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -5,7 +5,7 @@ title: Introduction
 
 # Introduction to Pioneer
 
-!!!success 📣 Pioneer v1 is in beta!
+!!!success 📣 Pioneer v1 is generally available!
 <small>See what's new!</small>
 <br/>
 <small>Docs for Pioneer v0 are [available here](/v0/features/async-await)</small>

--- a/Documentation/fundamentals/faq.md
+++ b/Documentation/fundamentals/faq.md
@@ -1,0 +1,8 @@
+---
+icon: cross-reference
+order: -1
+redirect: https://github.com/d-exclaimation/pioneer/discussions/categories/q-a
+---
+
+# FAQ
+

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -271,27 +271,28 @@ For further reading, the team at [Apollo GraphQL](https://www.apollographql.com/
 
 Now, it's time to integrate Pioneer into the existing Vapor application using the resolver and schema declared before.
 
-### Basic Vapor application
-
-First, let's setup a basic Vapor application.
-
-```swift # main.swift
-import Vapor
-
-let app = try Application(.detect())
-
-defer {
-    app.shutdown()
-}
-
-try app.run()
-```
-
 ### Pioneer configuration
 
-Now, create an instance of Pioneer with the desired configuration.
+First, create an instance of Pioneer with the desired configuration.
 
-```swift #1,6-12 main.swift
+```swift #
+import Pioneer
+
+let server = try Pioneer(
+    schema: schema(),
+    resolver: Resolver(),
+    httpStrategy: .csrfPrevention,
+    introspection: true,
+    playground: .sandbox
+)
+```
+
+
+### Basic Vapor application
+
+Next, let's setup a basic Vapor application.
+
+```swift #2,4,14-16,18 main.swift
 import Pioneer
 import Vapor
 
@@ -311,6 +312,32 @@ defer {
 
 try app.run()
 ```
+
+!!!success
+Pioneer can also run as a [standalone server](/web-frameworks/standalone) without needing to setup a Vapor application.
+
+==- Using standalone
+```swift #11-16 main.swift
+import Pioneer
+
+let server = try Pioneer(
+    schema: schema(),
+    resolver: Resolver(),
+    httpStrategy: .csrfPrevention,
+    introspection: true,
+    playground: .sandbox
+)
+
+try server.standaloneServer(
+    at: "graphql",
+    context: { req, res in
+        Context(req, res)
+    }
+)
+
+```
+===
+!!!
 
 ### Pioneer as Vapor middleware
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -41,7 +41,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.2.1"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.67.1"),
-        .package(url: "https://github.com/d-exclaimation/pioneer", from: "1.0.0-beta")
+        .package(url: "https://github.com/d-exclaimation/pioneer", from: "1.0.0")
     ],
     targets: [
         .target(

--- a/Documentation/v1/changelog.md
+++ b/Documentation/v1/changelog.md
@@ -1,6 +1,6 @@
 ---
 icon: history
-redirect: https://github.com/d-exclaimation/pioneer/releases/tag/1.0.0-beta
+redirect: https://github.com/d-exclaimation/pioneer/releases/tag/1.0.0
 order: 9
 ---
 

--- a/Documentation/v1/migrating.md
+++ b/Documentation/v1/migrating.md
@@ -12,7 +12,7 @@ One of the big goal of [v1](/) is to bring fully bring a stable release of Pione
 Pioneer also now no longer a [Vapor](https://github.com/vapor/vapor)-only library and exposes more of its internal functions, structs, protocols, and classes which will allow integrations with other web frameworks.
 
 !!!success
-Pioneer [v1](/) will still have first-party integration for [Vapor](https://github.com/vapor/vapor).
+Pioneer [v1](/) will still have first-party integration for [Vapor](/web-frameworks/vapor).
 !!!
 
 ### Middleware
@@ -98,22 +98,22 @@ Pioneer now properly implement a WebSocket initialisation guard, which will fire
 
 ```swift #14-16
 let server = Pioneer(
-	schema: schema,
-	resolver: resolver
+    schema: schema,
+    resolver: resolver
 )
 
 app.middleware.use(
-	server.vaporMiddleware(
-		context: { req, res in
-			...
+    server.vaporMiddleware( 
+        context: { req, res in
+            ...
 		},
-		websocketContext: { req, payload, gql in
-			...
-		},
-		websocketGuard: { req, payload in 
-			...
-		}
-	)
+        websocketContext: { req, payload, gql in
+            ...
+        },
+        websocketGuard: { req, payload in
+            ...
+        }
+    )
 )
 ```
 
@@ -122,6 +122,35 @@ app.middleware.use(
 Pioneer [**v0**](/v0/guides/getting-started/server) uses 3 different paths for GraphQL over HTTP, GraphQL over WebSocket, and GraphQL IDE hosting.
 
 In [**v1**](/), Pioneer will use the same path for all of those, and will instead determine from the request whether is a GraphQL over HTTP request, a GraphQL over WebSocket upgrade request, or a GraphQL IDE request.
+
+
+### Standalone server
+
+Pioneer will also now include option to run [standalone](/web-frameworks/standalone).
+
+```swift #6-16
+let server = Pioneer(
+    schema: schema,
+    resolver: resolver
+)
+
+try server.standaloneServer(
+    context: { req, res in
+        ...
+	},
+    websocketContext: { req, payload, gql in
+        ...
+    },
+    websocketGuard: { req, payload in
+        ...
+    }
+)
+```
+
+
+!!!success
+Under the hood, the standalone server uses the [Vapor](/web-frameworks/vapor) integration.
+!!!
 
 ## Other changes
 

--- a/Documentation/web-frameworks/integration.md
+++ b/Documentation/web-frameworks/integration.md
@@ -47,7 +47,7 @@ The important part is parsing into [GraphQLRequest](https://swiftpackageindex.co
     - The variables should be under `variables` as JSON string
         - This is probably percent encoded, and also need to be parse into `[String: Map]?` if available
     - As long the query string is accessible, the request is not malformed and we can construct a [GraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/graphqlrequest) using that.
-3. If [GraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/graphqlrequest) can't be retreive by both approach 1 and 2, the request is malformed and the response should have status code of 404 Bad Request.
+3. If [GraphQLRequest](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/graphqlrequest) can't be retreive by both approach 1 and 2, the request is malformed and the response could also have status code of 400 Bad Request.
 
 ==- Example
 

--- a/Documentation/web-frameworks/standalone.md
+++ b/Documentation/web-frameworks/standalone.md
@@ -1,0 +1,90 @@
+---
+icon: cpu
+order: 9
+---
+
+# Standalone
+
+Pioneer also come with **first-party** integration for a standalone server. This aims to make developing with Pioneer even faster by not having to worry about setting up the server.
+
+!!!success
+Under the hood, the standalone server uses the [Vapor](/web-frameworks/vapor) integration.
+!!!
+
+```swift #11
+import Pioneer
+
+let server = Pioneer(
+    schema: schema,
+    resolver: Resolver(),
+    websocketProtocol: .graphqlWs,
+    introspection: true,
+    playground: .sandbox
+)
+
+try server.standaloneServer()
+```
+
+## Configuration
+
+The standalone server allow some configuration to be better suited for your use case and environment.
+
+### Port, Host, and Env
+
+The [.standaloneServer](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer) function can take specified:
+=== Port number (`port`)
+- Must be a valid port number and an `Integer`
+- Defaults to `4000`
+
+```swift #2
+try server.standaloneServer(
+    port: 8080
+)
+```
+===
+=== Hostname (`host`)
+- Must be a `String` containing either an IP address or `"localhost"`
+- Defaults to `127.0.0.1`
+
+```swift #2
+try server.standaloneServer(
+    host: "0.0.0.0"
+)
+```
+===
+=== Environment mode (`env`)
+- Must be either `"development"`, `"testing"`, `"production"`, `"dev"`, `"prod"`, or `"test"`.
+
+```swift #2
+try server.standaloneServer(
+    env: "production"
+)
+```
+
+<small><a href="https://docs.vapor.codes/basics/environment/#changing-environment">More info on environment mode</a></small>
+===
+
+### CORS
+
+Given that the standalone option is responsible setup the server, any middleware need to be configured by the function. 
+
+To allow CORS using a middleware, [.standaloneServer](https://swiftpackageindex.com/d-exclaimation/pioneer/documentation/pioneer/pioneer) function can take specified [CORSMiddleware.Configuration](https://docs.vapor.codes/advanced/middleware/?h=cors#cors-middleware).
+
+```swift #5-9
+try server.standaloneServer(
+    port: 443,
+    host: "0.0.0.0",
+    env: "production",
+    cors: .init(
+        allowedOrigin: .all,
+        allowedMethods: [.GET, .POST, .OPTIONS],
+        allowedHeaders: [.accept, .authorization, .contentType, .origin, .xRequestedWith, .userAgent, .accessControlAllowOrigin]
+    )  
+)
+```
+
+## Context
+
+Configuring context with the standalone server is identical with the [Vapor](/web-frameworks/vapor) integration.
+
+[!ref Context](/web-frameworks/vapor#context)

--- a/Documentation/web-frameworks/vapor.md
+++ b/Documentation/web-frameworks/vapor.md
@@ -9,6 +9,25 @@ Pioneer will have a built-in **first-party** integration with [Vapor](https://gi
 
 This integration added a couple additional benefits.
 
+```swift #15
+import Pioneer
+import Vapor
+
+let app = try Application(.detect())
+
+let server = Pioneer(
+    schema: schema,
+    resolver: Resolver(),
+    websocketProtocol: .graphqlWs,
+    introspection: true,
+    playground: .sandbox
+)
+
+app.middleware.use(
+    server.vaporMiddleware()
+)
+```
+
 ## Context
 
 ### HTTP-based Context

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pioneer is an open-source, [spec-compliant](https://github.com/d-exclaimation/gr
 ## Setup
 
 ```swift
-.package(url: "https://github.com/d-exclaimation/pioneer", from: "1.0.0-beta")
+.package(url: "https://github.com/d-exclaimation/pioneer", from: "1.0.0")
 ```
 
 ## Swift for GraphQL

--- a/Sources/Pioneer/Vapor/Pioneer+Standalone.swift
+++ b/Sources/Pioneer/Vapor/Pioneer+Standalone.swift
@@ -27,7 +27,7 @@ extension Pioneer {
         port: Int = 4000, 
         host: String = "127.0.0.1", 
         env: String = "development",
-        cors: CORSMiddleware? = nil
+        cors: CORSMiddleware.Configuration? = nil
     ) throws {
         let app = try Application(
             .specified(port: port, host: host, env: env)
@@ -41,7 +41,7 @@ extension Pioneer {
         app.middleware.use(middleware)
 
         if let cors = cors {
-            app.middleware.use(cors, at: .beginning)
+            app.middleware.use(CORSMiddleware(configuration: cors), at: .beginning)
         }
 
         try app.run()
@@ -67,7 +67,7 @@ extension Pioneer {
         context: @escaping VaporHTTPContext,
         websocketContext: @escaping VaporWebSocketContext,
         websocketGuard: @escaping VaporWebSocketGuard = { _, _ in },
-        cors: CORSMiddleware? = nil
+        cors: CORSMiddleware.Configuration? = nil
     ) throws {
         try vaporServer(
             middleware: vaporMiddleware(
@@ -102,7 +102,7 @@ extension Pioneer {
         body: HTTPBodyStreamStrategy = .collect, 
         context: @escaping VaporHTTPContext,
         websocketGuard: @escaping VaporWebSocketGuard = { _, _ in },
-        cors: CORSMiddleware? = nil
+        cors: CORSMiddleware.Configuration? = nil
     ) throws {
         try vaporServer(
             middleware: vaporMiddleware(
@@ -134,7 +134,7 @@ extension Pioneer {
         at path: PathComponent = "graphql",
         body: HTTPBodyStreamStrategy = .collect, 
         websocketGuard: @escaping VaporWebSocketGuard = { _, _ in },
-        cors: CORSMiddleware? = nil
+        cors: CORSMiddleware.Configuration? = nil
     ) throws where Context == Void {
         try vaporServer(
             middleware: vaporMiddleware(
@@ -169,7 +169,7 @@ extension Pioneer {
         context: @escaping VaporHTTPContext,
         websocketContext: @escaping VaporWebSocketContext,
         websocketGuard: @escaping VaporWebSocketGuard = { _, _ in },
-        cors: CORSMiddleware? = nil
+        cors: CORSMiddleware.Configuration? = nil
     ) throws {
         try vaporServer(
             middleware: vaporMiddleware(
@@ -204,7 +204,7 @@ extension Pioneer {
         body: HTTPBodyStreamStrategy = .collect, 
         context: @escaping VaporHTTPContext,
         websocketGuard: @escaping VaporWebSocketGuard = { _, _ in },
-        cors: CORSMiddleware? = nil
+        cors: CORSMiddleware.Configuration? = nil
     ) throws {
         try vaporServer(
             middleware: vaporMiddleware(
@@ -236,7 +236,7 @@ extension Pioneer {
         at path: [PathComponent],
         body: HTTPBodyStreamStrategy = .collect, 
         websocketGuard: @escaping VaporWebSocketGuard = { _, _ in },
-        cors: CORSMiddleware? = nil
+        cors: CORSMiddleware.Configuration? = nil
     ) throws where Context == Void {
         try vaporServer(
             middleware: vaporMiddleware(


### PR DESCRIPTION
First stable release of Pioneer. Pioneer have been under [v0.x](https://github.com/d-exclaimation/pioneer/releases/tag/0.10.1) for a while and it has shown little major issues. This brings a bit more confidence for me to start introducing major improvements and changes.

This pull request is all about finishing up Pioneer **v1** by making sure it is easy and straightforward to built integrations.

This is a continuation of other **v1** pull requests and finalising **v1**:
- #92 
- #93 
- #94 
- #95 
- #104 
- #105 

After this, **v1** will be generally available.

### Motivation

One of the goal is to allow more Web frameworks integrations. Vapor is a great Web framework, but similarly to [Apollo Server](https://www.apollographql.com/docs/apollo-server/integrations/integration-index/), Pioneer should not strictly restrict itself to one framework. 
At some point (possibly **v2**), Pioneer and its Vapor integration would be separate packages which allow user of the library to use other options if they see fit.

Another goal is catch up to [Apollo Server v4](https://www.apollographql.com/docs/apollo-server/migration) which have significant changes especially on the API of the library.

### Changes

- [x] Standalone server option