### PR TITLE
support >macOS 10.15

### DIFF
--- a/Documentation/pages/docs/getting-started.mdx
+++ b/Documentation/pages/docs/getting-started.mdx
@@ -54,14 +54,14 @@ let package = Package(
 )
 ```
 
-### Using Swift 5.5 or higher
+### Using Swift 5.5.2 or higher
 
-We will also restrict the platform of the project to macOS v12 or higher, to allow the use of Swift Concurrency.
+We will also restrict the platform of the project to macOS v10.15 or higher, to allow the use of Swift Concurrency.
 
 ```swift filename="Package.swift" {2-4} showLineNumbers copy
 let package = Package(
     platforms: [
-        .macOS(.v12)
+        .macOS(.v10_15),
     ],
     // ...
 )

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/async-kit.git",
         "state": {
           "branch": null,
-          "revision": "017dc7da68c1ec9f0f46fcd1a8002d14a5662732",
-          "version": "1.12.0"
+          "revision": "929808e51fea04f01de0e911ce826ef70c4db4ea",
+          "version": "1.15.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/GraphQLSwift/Graphiti.git",
         "state": {
           "branch": null,
-          "revision": "5b15e16bfaa75b56eded4a0bbcb58345b2e66c43",
-          "version": "1.2.1"
+          "revision": "8c0048e217b185da163c8ba83475948dc5b0174e",
+          "version": "1.2.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/GraphQLSwift/GraphQL.git",
         "state": {
           "branch": null,
-          "revision": "ebd2ea40676f8bcbdfd6088c408f3ed321c1a905",
-          "version": "2.4.0"
+          "revision": "a3011344bef0374fb72f4ad57a85460564eb8f0e",
+          "version": "2.4.5"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "0eacdf3c7eab6df493ce328f2e97c2873b3e1c1e",
-          "version": "4.67.1"
+          "revision": "888c8b68642c1d340b6b3e9b2b8445fb0f6148c9",
+          "version": "4.68.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Pioneer",
     platforms: [
-        .macOS(.v12),
+        .macOS(.v10_15),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
@@ -18,9 +18,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "2.4.0"),
-        .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.2.1"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.67.1"),
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "2.4.5"),
+        .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.2.2"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.68.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Swift Concurrency has been backdeployed to 10.15

https://github.com/vapor/vapor/pull/2926
https://github.com/GraphQLSwift/Graphiti/pull/89

and can be used on 10.15 and above.