### PR TITLE
Reserved paths for specific operation and protocol, Allow combination of upgrade Connection headers

### DIFF
--- a/Sources/Pioneer/Vapor/Extensions/Request/Request+WebSocket.swift
+++ b/Sources/Pioneer/Vapor/Extensions/Request/Request+WebSocket.swift
@@ -13,6 +13,6 @@ public extension Request {
         guard let connection = headers.first(name: .connection), let upgrade = headers.first(name: .upgrade) else {
             return false
         }
-        return connection.lowercased() == "upgrade" && upgrade.lowercased() == "websocket"
+        return connection.lowercased().contains("upgrade") && upgrade.lowercased().contains("websocket")
     }
 }


### PR DESCRIPTION
## Changelog
- HTTP now have a reserved endpoint `"**/http"`that will only serve HTTP request
- WebSocket now have a reserved endpoint `"**/websocket"`that will only serve WebSocket upgrade request
- Playground / IDE also now have reserved endpoint `"**/playground"`
- WebSocket is now more lenient allowing different values in `Connection` header as long as it is a Upgrade request