### PR TITLE
added: serialize in asScalar

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5.2
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Pioneer/Extensions/Int/UInt64+Nanoseconds.swift
+++ b/Sources/Pioneer/Extensions/Int/UInt64+Nanoseconds.swift
@@ -4,6 +4,7 @@
 //
 //  Created by d-exclaimation on 14:19.
 //
+import Vapor
 
 public extension Optional where WrappedType == UInt64 {
     /// Convert the given value in seconds into nanoseconds

--- a/Sources/Pioneer/GraphQL/BuiltinTypes.swift
+++ b/Sources/Pioneer/GraphQL/BuiltinTypes.swift
@@ -44,8 +44,20 @@ public struct ID: Codable, ExpressibleByStringLiteral, CustomStringConvertible, 
 
     /// Apply scalar to Graphiti schema to allow the use of ID.
     public static func asScalar<Resolver, Context>() -> Scalar<Resolver, Context, Self> {
-        .init(ID.self, as: "ID")
-            .description("The ID scalar type represents a unique identifier, often used to refetch an object or as the key for a cache. The ID type is serialized in the same way as a String; however, defining it as an ID signifies that it is not intended to be human‐readable")
+        .init(
+            ID.self,
+            as: "ID",
+            serialize: { value, _ in
+                try GraphQLID.serialize(value: value)
+            },
+            parseValue:  { inputValue, _ in
+                try GraphQLID.parseValue(value: inputValue)
+            },
+            parseLiteral:  { ast, _ in
+                try GraphQLID.parseLiteral(valueAST: ast)
+            }
+        )
+        .description("The ID scalar type represents a unique identifier, often used to refetch an object or as the key for a cache. The ID type is serialized in the same way as a String; however, defining it as an ID signifies that it is not intended to be human‐readable")
     }
 
     /// Create a new ID from UUID

--- a/Sources/Pioneer/GraphQL/BuiltinTypes.swift
+++ b/Sources/Pioneer/GraphQL/BuiltinTypes.swift
@@ -48,7 +48,11 @@ public struct ID: Codable, ExpressibleByStringLiteral, CustomStringConvertible, 
             ID.self,
             as: "ID",
             serialize: { value, _ in
-                try GraphQLID.serialize(value: value)
+                guard let idValue = value as? ID else {
+                    throw GraphQLError(message: "Failed to cast value \(value) to ID type")
+                }
+                    
+                return try GraphQLID.serialize(value: idValue.id)
             },
             parseValue:  { inputValue, _ in
                 try GraphQLID.parseValue(value: inputValue)

--- a/Sources/Pioneer/Vapor/Extensions/Request/GraphQLJSONEncoder+ContentEncoder.swift
+++ b/Sources/Pioneer/Vapor/Extensions/Request/GraphQLJSONEncoder+ContentEncoder.swift
@@ -8,7 +8,7 @@
 import class GraphQL.GraphQLJSONEncoder
 import Vapor
 
-extension GraphQLJSONEncoder: ContentEncoder {
+extension GraphQLJSONEncoder: Vapor.ContentEncoder {
     public func encode<E>(_ encodable: E, to body: inout NIOCore.ByteBuffer, headers: inout NIOHTTP1.HTTPHeaders) throws where E: Encodable {
         headers.contentType = .json
         try body.writeBytes(self.encode(encodable))

--- a/Sources/Pioneer/Vapor/Extensions/Response/GraphQLResult+Content.swift
+++ b/Sources/Pioneer/Vapor/Extensions/Response/GraphQLResult+Content.swift
@@ -8,4 +8,4 @@
 import struct GraphQL.GraphQLResult
 import protocol Vapor.Content
 
-extension GraphQLResult: Content {}
+extension GraphQLResult: Vapor.Content {}

--- a/Sources/Pioneer/Vapor/Http/Pioneer+IDE.swift
+++ b/Sources/Pioneer/Vapor/Http/Pioneer+IDE.swift
@@ -19,7 +19,7 @@ extension Pioneer {
         case .sandbox:
             return serve(html: embeddedSandboxHtml)
         case let .redirect(to: cloud):
-            return req.redirect(to: cloud.url, type: .permanent)
+            return req.redirect(to: cloud.url, redirectType: .permanent)
         case .disable:
             return Response(status: .notFound)
         }

--- a/Sources/Pioneer/Vapor/WebSocket/Pioneer+WebSocket.swift
+++ b/Sources/Pioneer/Vapor/WebSocket/Pioneer+WebSocket.swift
@@ -38,6 +38,7 @@ public extension Pioneer {
     }
 
     /// Should upgrade callback
+    @Sendable
     internal func shouldUpgrade(req: Request) -> EventLoopFuture<HTTPHeaders?> {
         req.eventLoop.makeSucceededFuture(.init([("Sec-WebSocket-Protocol", websocketProtocol.name)]))
     }

--- a/Tests/PioneerTests/VaporTests/HTTPQueryTests.swift
+++ b/Tests/PioneerTests/VaporTests/HTTPQueryTests.swift
@@ -78,9 +78,11 @@ final class HTTPQueryTests: XCTestCase {
         let gql3 = GraphQLRequest(query: "query { error { id, name } }")
         let gql4 = GraphQLRequest(query: "query { invalid }")
 
-        let app = Application(.testing)
+        let app = try await Application.make(.testing)
         defer {
-            app.shutdown()
+            Task{
+                try await app.asyncShutdown()
+            }
         }
 
         app.middleware.use(server.vaporMiddleware(), at: .beginning)
@@ -181,9 +183,11 @@ final class HTTPQueryTests: XCTestCase {
         let gql3 = "query=" + "query { error { id, name } }".addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
         let gql4 = "query=" + "query { invalid }".addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
 
-        let app = Application(.testing)
+        let app = try await Application.make(.testing)
         defer {
-            app.shutdown()
+            Task{
+                try await app.asyncShutdown()
+            }
         }
 
         app.middleware.use(server.vaporMiddleware(), at: .beginning)


### PR DESCRIPTION
added serialize to asScalar function and fix swift 6 warnings

I encountered the bug described [here](https://github.com/GraphQLSwift/GraphQL/issues/157). This pull request fixes it.